### PR TITLE
Dynamic field bucket method

### DIFF
--- a/src/explorer.ipynb
+++ b/src/explorer.ipynb
@@ -11,9 +11,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-03-28 10:13:36 INFO     Note: NumExpr detected 16 cores but \"NUMEXPR_MAX_THREADS\" not set, so enforcing safe limit of 8.\n",
+      "2022-03-28 10:13:36 INFO     NumExpr defaulting to 8 threads.\n"
+     ]
+    }
+   ],
    "source": [
     "from fmu.sumo.explorer import Explorer\n",
     "import xtgeo\n",
@@ -37,9 +46,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-03-28 10:13:39 INFO     Getting access token\n",
+      "2022-03-28 10:13:40 INFO     Access token found\n"
+     ]
+    }
+   ],
    "source": [
     "sumo = Explorer(env=\"dev\", write_back=True)"
    ]
@@ -62,9 +80,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'JOHAN SVERDRUP': 74, 'DROGON': 9}\n"
+     ]
+    }
+   ],
    "source": [
     "fields = sumo.get_fields()\n",
     "\n",

--- a/src/explorer.ipynb
+++ b/src/explorer.ipynb
@@ -11,18 +11,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2022-03-28 10:13:36 INFO     Note: NumExpr detected 16 cores but \"NUMEXPR_MAX_THREADS\" not set, so enforcing safe limit of 8.\n",
-      "2022-03-28 10:13:36 INFO     NumExpr defaulting to 8 threads.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from fmu.sumo.explorer import Explorer\n",
     "import xtgeo\n",
@@ -46,18 +37,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2022-03-28 10:13:39 INFO     Getting access token\n",
-      "2022-03-28 10:13:40 INFO     Access token found\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "sumo = Explorer(env=\"dev\", write_back=True)"
    ]
@@ -80,17 +62,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'JOHAN SVERDRUP': 74, 'DROGON': 9}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "fields = sumo.get_fields()\n",
     "\n",
@@ -350,6 +324,174 @@
     "\n",
     "print(realizations)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Case.get_object_property_values()\n",
+    "\n",
+    "Get distinct values for a property for a specific object type. I.e: get distinct object names for surfaces.\n",
+    "Can be used to get values that can be used in filtering when retrieving objects.\n",
+    "\n",
+    "This method will can replace all the other `get_object_*`-methods:\n",
+    "- get_object_tag_name\n",
+    "- get_object_names\n",
+    "- get_object_aggregations\n",
+    "- get_object_time_intervals\n",
+    "\n",
+    "\n",
+    "Params:\n",
+    "- property: string\n",
+    "- object_type: string\n",
+    "- object_name: string\n",
+    "- tag_name: string\n",
+    "- iteration_id: number\n",
+    "- realization_id: number\n",
+    "- aggregation: string\n",
+    "\n",
+    "`property` and `object_type` are required, the rest of the parameters are used for filtering and are optional.\n",
+    "\n",
+    "Valid `property` values:\n",
+    "- tag_name\n",
+    "- object_name\n",
+    "- time_interval\n",
+    "- aggregation\n",
+    "- iteration_id\n",
+    "- realization_id\n",
+    "\n",
+    "Valid `object_type` values:\n",
+    "- surface\n",
+    "- polygons\n",
+    "- table\n",
+    "\n",
+    "Returns \n",
+    "```\n",
+    "Dict {\n",
+    "    [PROPERTY VALUE]: COUNT\n",
+    "}\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example: filter down to unique surface object\n",
+    "\n",
+    "This example uses the `get_object_property_values` in several steps to get values that uniquley identifies a surface object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get iteration_ids\n",
+    "iteration_ids = my_case.get_object_property_values(\n",
+    "    property=\"iteration_id\",\n",
+    "    object_type=\"surface\"\n",
+    ")\n",
+    "\n",
+    "print(iteration_ids)\n",
+    "\n",
+    "iteration_id = list(iteration_ids.keys())[0]\n",
+    "\n",
+    "# use the retrieved iteration_id to get tag_names for surfaces within this iteration\n",
+    "tag_names = my_case.get_object_property_values(\n",
+    "    property=\"tag_name\",\n",
+    "    object_type=\"surface\",\n",
+    "    iteration_id=iteration_id,\n",
+    ")\n",
+    "\n",
+    "print(tag_names)\n",
+    "\n",
+    "tag_name = list(tag_names.keys())[5]\n",
+    "\n",
+    "# use the retrieved tag_name to get object_names for surfaces containing this tag_name\n",
+    "object_names = my_case.get_object_property_values(\n",
+    "    property=\"object_name\",\n",
+    "    object_type=\"surface\",\n",
+    "    iteration_id=iteration_id,\n",
+    "    tag_name=tag_name\n",
+    ")\n",
+    "\n",
+    "print(object_names)\n",
+    "\n",
+    "object_name = list(object_names.keys())[2]\n",
+    "\n",
+    "# use the object_name, tag_name and iteration_id to get available time_intervals\n",
+    "time_intervals = my_case.get_object_property_values(\n",
+    "    property=\"time_interval\",\n",
+    "    object_type=\"surface\",\n",
+    "    iteration_id=iteration_id,\n",
+    "    tag_name=tag_name,\n",
+    "    object_name=object_name\n",
+    ")\n",
+    "\n",
+    "print(time_intervals)\n",
+    "\n",
+    "time_interval = list(time_intervals.keys())[2]\n",
+    "\n",
+    "# use the object_name, tag_name and iteration_id to get available aggregations\n",
+    "aggregations = my_case.get_object_property_values(\n",
+    "    property=\"aggregation\",\n",
+    "    object_type=\"surface\",\n",
+    "    iteration_id=iteration_id,\n",
+    "    tag_name=tag_name,\n",
+    "    object_name=object_name\n",
+    ")\n",
+    "\n",
+    "print(aggregations)\n",
+    "\n",
+    "aggregation = list(aggregations.keys())[3]\n",
+    "\n",
+    "# get available realization_ids based on iteration_id, object_name, tag_name and time_interval\n",
+    "realization_ids = my_case.get_object_property_values(\n",
+    "    property=\"realization_id\",\n",
+    "    object_type=\"surface\",\n",
+    "    iteration_id=iteration_id,\n",
+    "    tag_name=tag_name,\n",
+    "    object_name=object_name,\n",
+    "    time_interval=time_interval\n",
+    ")\n",
+    "\n",
+    "print(realization_ids)\n",
+    "\n",
+    "realization_id = list(realization_ids.keys())[7]\n",
+    "\n",
+    "# get surface from realization\n",
+    "surfaces = my_case.get_objects(\n",
+    "    object_type=\"surface\",\n",
+    "    iteration_id=iteration_id,\n",
+    "    tag_name=tag_name,\n",
+    "    object_name=object_name,\n",
+    "    time_interval=time_interval,\n",
+    "    realization_id=realization_id\n",
+    ")\n",
+    "\n",
+    "print(len(surfaces))\n",
+    "\n",
+    "# get aggregated surface\n",
+    "surfaces = my_case.get_objects(\n",
+    "    object_type=\"surface\",\n",
+    "    iteration_id=iteration_id,\n",
+    "    tag_name=tag_name,\n",
+    "    object_name=object_name,\n",
+    "    time_interval=time_interval,\n",
+    "    aggregation=aggregation\n",
+    ")\n",
+    "\n",
+    "print(len(surfaces))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",

--- a/src/explorer.ipynb
+++ b/src/explorer.ipynb
@@ -334,7 +334,7 @@
     "Get distinct values for a property for a specific object type. I.e: get distinct object names for surfaces.\n",
     "Can be used to get values that can be used in filtering when retrieving objects.\n",
     "\n",
-    "This method will can replace all the other `get_object_*`-methods:\n",
+    "This method is mean to be dynamic and flexible and can replace all the other `get_object_*`-methods:\n",
     "- get_object_tag_name\n",
     "- get_object_names\n",
     "- get_object_aggregations\n",
@@ -379,7 +379,7 @@
    "source": [
     "#### Example: filter down to unique surface object\n",
     "\n",
-    "This example uses the `get_object_property_values` in several steps to get values that uniquley identifies a surface object"
+    "This example uses the `get_object_property_values` in several steps to get values that uniquley identifies a surface object."
    ]
   },
   {

--- a/src/fmu/sumo/explorer/_case.py
+++ b/src/fmu/sumo/explorer/_case.py
@@ -196,7 +196,7 @@ class Case:
             aggregate_field="tag_name",
         )
 
-        result = self.sumo.post("/debug-search", json=elastic_query)
+        result = self.sumo.post("/search", json=elastic_query)
         buckets = result.json()["aggregations"]["tag_name"]["buckets"]
 
         return self.utils.map_buckets(buckets)
@@ -234,7 +234,7 @@ class Case:
             aggregate_field="data.name.keyword",
         )
 
-        result = self.sumo.post("/debug-search", json=elastic_query)
+        result = self.sumo.post("/search", json=elastic_query)
         buckets = result.json()["aggregations"]["data.name.keyword"]["buckets"]
 
         return self.utils.map_buckets(buckets)
@@ -276,7 +276,7 @@ class Case:
             aggregate_field="time_interval",
         )
 
-        result = self.sumo.post("/debug-search", json=elastic_query)
+        result = self.sumo.post("/search", json=elastic_query)
         buckets = result.json()["aggregations"]["time_interval"]["buckets"]
 
         return self.utils.map_buckets(buckets)
@@ -307,14 +307,14 @@ class Case:
             aggregate_field="fmu.aggregation.operation.keyword",
         )
 
-        result = self.sumo.post("/debug-search", json=elastic_query)
+        result = self.sumo.post("/search", json=elastic_query)
         buckets = result.json()["aggregations"]["fmu.aggregation.operation.keyword"]["buckets"]
 
         return self.utils.map_buckets(buckets)
 
-    def get_object_field_values(
+    def get_object_property_values(
         self,
-        field,
+        property,
         object_type,
         object_name=None,
         tag_name=None,
@@ -323,7 +323,7 @@ class Case:
         realization_id=None,
         aggregation=None
     ):
-        accepted_fields = {
+        accepted_properties = {
             "tag_name": "tag_name",
             "time_interval": "time_interval",
             "aggregation": "fmu.aggregation.operation.keyword",
@@ -332,11 +332,10 @@ class Case:
             "realization_id": "fmu.realization.id"
         }
 
-        if field not in accepted_fields.keys():
-            raise Exception(f"Invalid field: {field}. Accepted fields: {accepted_fields.keys()}")
+        if property not in accepted_properties.keys():
+            raise Exception(f"Invalid field: {property}. Accepted fields: {accepted_properties.keys()}")
 
         fields_match = {"_sumo.parent_object": self.sumo_id}
-        fields_exists = []
 
         if iteration_id is not None:
             fields_match["fmu.iteration.id"] = iteration_id
@@ -355,19 +354,16 @@ class Case:
 
         if aggregation:
             fields_match["fmu.aggregation.operation"] = aggregation
-        else:
-            fields_exists.append("fmu.realization.id")
 
-        agg_field = accepted_fields[field]
+        agg_field = accepted_properties[property]
 
         elastic_query = self._create_elastic_query(
             object_type=object_type,
-            fields_exists=fields_exists,
             fields_match=fields_match,
-            aggregate_field=agg_field,
+            aggregate_field=agg_field
         )
 
-        result = self.sumo.post("/debug-search", json=elastic_query)
+        result = self.sumo.post("/search", json=elastic_query)
         buckets = result.json()["aggregations"][agg_field]["buckets"]
 
         return self.utils.map_buckets(buckets)
@@ -413,7 +409,7 @@ class Case:
             size=0
         )
 
-        result = self.sumo.post("/debug-search", json=query)
+        result = self.sumo.post("/search", json=query)
         count = result.json()["hits"]["total"]["value"]
 
         if object_type == "surface":

--- a/src/fmu/sumo/explorer/_utils.py
+++ b/src/fmu/sumo/explorer/_utils.py
@@ -1,8 +1,9 @@
 class Utils:
     def map_buckets(self, buckets):
         mapped = {}
+        buckets_sorted = sorted(buckets, key=lambda b: b['key'])
 
-        for bucket in buckets:
+        for bucket in buckets_sorted:
             mapped[bucket["key"]] = bucket["doc_count"]
 
         return mapped


### PR DESCRIPTION
Testing a more flexible and dynamic way of creating buckets on properties.

Instead of a number of methods for creating buckets on various fields, you can now use `get_object_property_values` to get distinct values for a given property within case objects. This can replace the existing methods:
- get_object_tag_name
- get_object_names
- get_object_aggregations
- get_object_time_intervals

`explorer.ipynb` has been updated with documentation and examples.

#### Example
Getting distinct tag_names within iteration.
```python
# old
tag_names = my_case.get_object_tag_names(
    object_type="surface",
    iteration_id=0,
)

# new
tag_names = my_case.get_object_property_values(
    property="tag_name",
    object_type="surface",
    iteration_id=0
)
```
