### PR TITLE
add package to required installs in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "setuptools",
         "oneseismic",
         "azure-core",
+        "deprecated"
     ],
     python_requires=">=3.6",
     packages=find_packages("src"),


### PR DESCRIPTION
The `deprecated` package was missing in setup.py which resulted in an error when testing the Explorer in komodo-bleeding.