### PR TITLE
Added get_objects method to Explorer class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 /dist
 /build
 venv
+/src/testing.py

--- a/src/fmu/sumo/explorer/_case.py
+++ b/src/fmu/sumo/explorer/_case.py
@@ -296,7 +296,9 @@ class Case:
         if property not in accepted_properties.keys():
             raise Exception(f"Invalid field: {property}. Accepted fields: {accepted_properties.keys()}")
 
-        terms = {}
+        terms = {
+            "_sumo.parent_object.keyword": [self.sumo_id]
+        }
 
         if iteration_ids:
             terms["fmu.iteration.id"] = iteration_ids
@@ -318,7 +320,7 @@ class Case:
 
         agg_field = accepted_properties[property]
 
-        elastic_query = self._create_elastic_query(
+        elastic_query = self.utils.create_elastic_query(
             object_type=object_type,
             terms=terms,
             aggregate_field=agg_field
@@ -356,7 +358,9 @@ class Case:
                 `DocumentCollection` used for retrieving search results
         """
 
-        terms = {}
+        terms = {
+            "_sumo.parent_object.keyword": [self.sumo_id]
+        }
         fields_exists = []
 
         if iteration_ids:
@@ -379,7 +383,7 @@ class Case:
         else:
             fields_exists.append("fmu.realization.id")
 
-        query = self._create_elastic_query(
+        query = self.utils.create_elastic_query(
             object_type=object_type,
             fields_exists=fields_exists,
             terms=terms,

--- a/src/fmu/sumo/explorer/_utils.py
+++ b/src/fmu/sumo/explorer/_utils.py
@@ -1,3 +1,9 @@
+OBJECT_TYPES = {
+    'surface': '.gri',
+    'polygons': '.csv',
+    'table': '.csv'
+}
+
 class Utils:
     def map_buckets(self, buckets):
         mapped = {}
@@ -7,3 +13,118 @@ class Utils:
             mapped[bucket["key"]] = bucket["doc_count"]
 
         return mapped
+
+
+    def create_elastic_query(
+            self, 
+            object_type='surface',
+            size=0, 
+            sort=None,
+            terms={}, 
+            fields_exists=[],
+            aggregate_field=None
+    ):
+        if object_type not in list(OBJECT_TYPES.keys()):
+            raise Exception(f"Invalid object_type: {object_type}. Accepted object_types: {OBJECT_TYPES.keys()}")
+
+        elastic_query = {
+            "size": size, 
+            "runtime_mappings": {
+                "time_start": {
+                    "type": "keyword",
+                    "script": {
+                        "lang": "painless", 
+                        "source": """
+                            def time = params['_source']['data']['time'];
+                            
+                            if(time != null && time.length > 1) {
+                                emit(params['_source']['data']['time'][1]['value'].splitOnToken('T')[0]); 
+                            } else {
+                                emit('NULL');
+                            }
+                        """
+                    }
+                },
+                "time_end": {
+                    "type": "keyword",
+                    "script": {
+                        "lang": "painless", 
+                        "source": """
+                            def time = params['_source']['data']['time'];
+                            
+                            if(time != null && time.length > 0) {
+                                emit(params['_source']['data']['time'][0]['value'].splitOnToken('T')[0]); 
+                            } else {
+                                emit('NULL');
+                            }
+                        """
+                    }
+                },
+                "time_interval": {
+                    "type": "keyword",
+                    "script": {
+                        "lang": "painless", 
+                        "source": """
+                            def time = params['_source']['data']['time'];
+                            
+                            if(time != null) {
+                                if(time.length > 1) {
+                                String start = params['_source']['data']['time'][1]['value'].splitOnToken('T')[0];
+                                String end = params['_source']['data']['time'][0]['value'].splitOnToken('T')[0];
+                                
+                                emit(start + ' - ' + end);
+                                } else if(time.length > 0) {
+                                emit(params['_source']['data']['time'][0]['value'].splitOnToken('T')[0]);
+                                }
+                            }else {
+                                emit('NULL');
+                            }
+                        """
+                    }
+                },
+                "tag_name": {
+                    "type": "keyword",
+                    "script": {
+                        "source": f"""
+                            String[] split_path = doc['file.relative_path.keyword'].value.splitOnToken('/');
+                            String file_name = split_path[split_path.length - 1];
+                            String surface_content = file_name.splitOnToken('--')[1].replace('{OBJECT_TYPES[object_type]}', '');
+                            emit(surface_content);
+                        """
+                    }
+                }
+            },
+            "query": {
+                "bool": {
+                    "must": [
+                        {"match": {"class": object_type}}
+                    ]
+                }
+            },
+            "fields": ["tag_name", "time_start", "time_end", "time_interval"]
+        }
+
+        if sort:
+            elastic_query["sort"] = sort
+
+        for field in terms:
+            elastic_query["query"]["bool"]["must"].append({
+                "terms": {field: terms[field]}
+            })
+
+        for field in fields_exists:
+            elastic_query["query"]["bool"]["must"].append({
+                "exists": { "field": field}
+            })
+
+        if aggregate_field:
+            elastic_query["aggs"] = {
+                aggregate_field: {
+                    "terms": {
+                        "field": aggregate_field,
+                        "size": 300
+                    }
+                }
+            }
+
+        return elastic_query


### PR DESCRIPTION
Added `get_objects` method to Explorer class with possibility to filter by case_ids:

```python
from fmu.sumo.explorer import Explorer

sumo = Explorer("dev", interactive=True)

objects = sumo.get_objects(
    "surface", 
    case_ids=["dba9bba9-7a74-3207-8f96-b08b4ae23d6d"], 
    iteration_ids=[0], 
    realization_ids=[0]
)

print(len(objects))
```

As requested by the Webviz team, they would like to be able to fetch the objects with less steps. This way they won't have to get the case object before getting the child objects.