### PR TITLE
Reverse order of ert.shared vs ert_shared imports

### DIFF
--- a/src/fmu/sumo/uploader/scripts/sumo_upload.py
+++ b/src/fmu/sumo/uploader/scripts/sumo_upload.py
@@ -9,9 +9,9 @@ import logging
 from pathlib import Path
 
 try:
-    from ert_shared.plugins.plugin_manager import hook_implementation  # type: ignore
-except ModuleNotFoundError:
     from ert.shared.plugins.plugin_manager import hook_implementation  # type: ignore
+except ModuleNotFoundError:
+    from ert_shared.plugins.plugin_manager import hook_implementation  # type: ignore
 
 try:
     from ert import ErtScript # type: ignore


### PR DESCRIPTION
Importing the deprecated ert_shared first in the try clause might trigger deprecation warnings.