### PR TITLE
Exlude/include time data

### DIFF
--- a/src/fmu/sumo/explorer/__init__.py
+++ b/src/fmu/sumo/explorer/__init__.py
@@ -1,5 +1,5 @@
 from fmu.sumo.explorer._explorer import Explorer
 from fmu.sumo.explorer._case import Case
-from fmu.sumo.explorer._utils import Utils
+from fmu.sumo.explorer._utils import Utils, TimeData
 from fmu.sumo.explorer._child_object import ChildObject
 from fmu.sumo.explorer._document_collection import DocumentCollection

--- a/src/fmu/sumo/explorer/__init__.py
+++ b/src/fmu/sumo/explorer/__init__.py
@@ -1,5 +1,5 @@
 from fmu.sumo.explorer._explorer import Explorer
 from fmu.sumo.explorer._case import Case
-from fmu.sumo.explorer._utils import Utils, TimeData
+from fmu.sumo.explorer._utils import Utils, TimeData, Property, ObjectType
 from fmu.sumo.explorer._child_object import ChildObject
 from fmu.sumo.explorer._document_collection import DocumentCollection

--- a/src/fmu/sumo/explorer/_case.py
+++ b/src/fmu/sumo/explorer/_case.py
@@ -172,7 +172,7 @@ class Case:
         iteration_ids: List[str]=[],
         realization_ids: List[int]=[],
         aggregations: List[int]=[],
-        include_time_data: TimeData = TimeData.ALL
+        include_time_data: TimeData = None
     ):
         """
             Get a dictionary of unique values for a given property in case child objects.
@@ -250,7 +250,7 @@ class Case:
         iteration_ids: List[int]=[],
         realization_ids: List[int]=[],
         aggregations: List[str]=[],
-        include_time_data: TimeData = TimeData.ALL
+        include_time_data: TimeData = None
     ):
         """
             Search for child objects in a case.

--- a/src/fmu/sumo/explorer/_case.py
+++ b/src/fmu/sumo/explorer/_case.py
@@ -1,14 +1,8 @@
 from typing import List
-from fmu.sumo.explorer._utils import Utils, TimeData
+from fmu.sumo.explorer._utils import Utils, TimeData, Property, ObjectType
 from fmu.sumo.explorer._document_collection import DocumentCollection
 from fmu.sumo.explorer._child_object import ChildObject
 import deprecation
-
-OBJECT_TYPES = {
-    'surface': '.gri',
-    'polygons': '.csv',
-    'table': '.csv'
-}
 
 class Case:
     def __init__(self, sumo_client, meta_data):
@@ -164,8 +158,8 @@ class Case:
     
     def get_object_property_values(
         self,
-        property: str,
-        object_type: str,
+        property: Property,
+        object_type: ObjectType,
         object_names: List[str]=[],
         tag_names: List[str]=[],
         time_intervals: List[str]=[],
@@ -178,8 +172,8 @@ class Case:
             Get a dictionary of unique values for a given property in case child objects.
 
             Arguments:
-                `property`: tag_name | time_interval | time_type | aggregation | object_name | iteration_id | realization_id (string)
-                `object_type`: surface | polygons | table (string)
+                `property`: tag_name | time_interval | time_type | aggregation | object_name | iteration_id | realization_id (Property)
+                `object_type`: surface | polygons | table (ObjectType)
                 `object_names`: list of object names (strings)
                 `tag_names`: list of tag names (strings)
                 `time_intervals`: list of time intervals (strings)
@@ -244,7 +238,7 @@ class Case:
 
     def get_objects(
         self,
-        object_type: str,
+        object_type: ObjectType,
         object_names: List[str]=[],
         tag_names: List[str]=[],
         time_intervals: List[str]=[],
@@ -257,7 +251,7 @@ class Case:
             Search for child objects in a case.
 
             Arguments:
-                `object_type`: surface | polygons | table
+                `object_type`: surface | polygons | table (ObjectType)
                 `object_names`: list of object names (strings)
                 `tag_names`: list of tag names (strings)
                 `time_intervals`: list of time intervals (strings)

--- a/src/fmu/sumo/explorer/_case.py
+++ b/src/fmu/sumo/explorer/_case.py
@@ -178,7 +178,7 @@ class Case:
             Get a dictionary of unique values for a given property in case child objects.
 
             Arguments:
-                `property`: tag_name | time_interval | aggregation | object_name | iteration_id | realization_id (string)
+                `property`: tag_name | time_interval | time_type | aggregation | object_name | iteration_id | realization_id (string)
                 `object_type`: surface | polygons | table (string)
                 `object_names`: list of object names (strings)
                 `tag_names`: list of tag names (strings)
@@ -195,6 +195,7 @@ class Case:
         accepted_properties = {
             "tag_name": "tag_name",
             "time_interval": "time_interval",
+            "time_type": "time_type",
             "aggregation": "fmu.aggregation.operation.keyword",
             "object_name": "data.name.keyword",
             "iteration_id": "fmu.iteration.id",

--- a/src/fmu/sumo/explorer/_case.py
+++ b/src/fmu/sumo/explorer/_case.py
@@ -171,7 +171,8 @@ class Case:
         time_intervals: List[str]=[],
         iteration_ids: List[str]=[],
         realization_ids: List[int]=[],
-        aggregations: List[int]=[]
+        aggregations: List[int]=[],
+        exclude_time_data: bool = False
     ):
         """
             Get a dictionary of unique values for a given property in case child objects.
@@ -205,6 +206,9 @@ class Case:
         terms = {
             "_sumo.parent_object.keyword": [self.sumo_id]
         }
+
+        if exclude_time_data:
+            terms["time_interval"] = ["NULL"]
 
         if iteration_ids:
             terms["fmu.iteration.id"] = iteration_ids
@@ -246,7 +250,8 @@ class Case:
         time_intervals: List[str]=[],
         iteration_ids: List[int]=[],
         realization_ids: List[int]=[],
-        aggregations: List[str]=[]
+        aggregations: List[str]=[],
+        exclude_time_data: bool = False
     ):
         """
             Search for child objects in a case.
@@ -268,6 +273,9 @@ class Case:
             "_sumo.parent_object.keyword": [self.sumo_id]
         }
         fields_exists = []
+
+        if exclude_time_data:
+            terms["time_interval"] = ["NULL"]
 
         if iteration_ids:
             terms["fmu.iteration.id"] = iteration_ids

--- a/src/fmu/sumo/explorer/_explorer.py
+++ b/src/fmu/sumo/explorer/_explorer.py
@@ -1,6 +1,6 @@
 from sumo.wrapper import SumoClient
 from fmu.sumo.explorer._case import Case
-from fmu.sumo.explorer._utils import Utils
+from fmu.sumo.explorer._utils import Utils, TimeData
 from fmu.sumo.explorer._document_collection import DocumentCollection
 from typing import List
 from fmu.sumo.explorer._child_object import ChildObject
@@ -112,7 +112,8 @@ class Explorer:
         time_intervals: List[str]=[],
         iteration_ids: List[int]=[],
         realization_ids: List[int]=[],
-        aggregations: List[str]=[]
+        aggregations: List[str]=[],
+        include_time_data: TimeData = None
     ):
         """
             Search for child objects in a case.
@@ -161,7 +162,8 @@ class Explorer:
             fields_exists=fields_exists,
             terms=terms,
             size=20,
-            sort=[{"tracklog.datetime": "desc"}]
+            sort=[{"tracklog.datetime": "desc"}],
+            include_time_data=include_time_data
         )
 
         return DocumentCollection(

--- a/src/fmu/sumo/explorer/_explorer.py
+++ b/src/fmu/sumo/explorer/_explorer.py
@@ -1,6 +1,6 @@
 from sumo.wrapper import SumoClient
 from fmu.sumo.explorer._case import Case
-from fmu.sumo.explorer._utils import Utils, TimeData
+from fmu.sumo.explorer._utils import Utils, TimeData, ObjectType
 from fmu.sumo.explorer._document_collection import DocumentCollection
 from typing import List
 from fmu.sumo.explorer._child_object import ChildObject
@@ -105,7 +105,7 @@ class Explorer:
         
     def get_objects(
         self,
-        object_type: str,
+        object_type: ObjectType,
         case_ids: List[str]=[],
         object_names: List[str]=[],
         tag_names: List[str]=[],
@@ -119,7 +119,7 @@ class Explorer:
             Search for child objects in a case.
 
             Arguments:
-                `object_type`: surface | polygons | table
+                `object_type`: surface | polygons | table (ObjectType)
                 `object_names`: list of object names (strings)
                 `tag_names`: list of tag names (strings)
                 `time_intervals`: list of time intervals (strings)

--- a/src/fmu/sumo/explorer/_utils.py
+++ b/src/fmu/sumo/explorer/_utils.py
@@ -80,6 +80,11 @@ class Utils:
             "fields": ["tag_name", "time_interval"]
         }
 
+        if aggregate_field in ["tag_name", "time_interval"]:
+            elastic_query["query"]["bool"]["must_not"] = [
+                {"term": {aggregate_field: "NULL"}}
+            ]
+
         if sort:
             elastic_query["sort"] = sort
 

--- a/src/fmu/sumo/explorer/_utils.py
+++ b/src/fmu/sumo/explorer/_utils.py
@@ -1,8 +1,10 @@
 from enum import Enum
+
 class TimeData(str, Enum):
     ALL = "ALL"
-    ONLY_TIMEDATA = "ONLY_TIMEDATA"
-    NO_TIMEDATA = "NO_TIMEDATA"
+    TIMESTAMP = "TIMESTAMP"
+    TIME_INTERVAL = "TIME_INTERVAL"
+    NONE = "NONE"
 
 
 OBJECT_TYPES = {
@@ -30,7 +32,7 @@ class Utils:
             terms={}, 
             fields_exists=[],
             aggregate_field=None,
-            include_time_data=TimeData.ALL
+            include_time_data=None
     ):
         if object_type not in list(OBJECT_TYPES.keys()):
             raise Exception(f"Invalid object_type: {object_type}. Accepted object_types: {OBJECT_TYPES.keys()}")
@@ -55,7 +57,30 @@ class Utils:
                                     emit(params['_source']['data']['time'][0]['value'].splitOnToken('T')[0]);
                                 }
                             }else {
-                                emit('NULL');
+                                emit('NONE');
+                            }
+                        """
+                    }
+                },
+                "time_type": {
+                    "type": "keyword",
+                    "script": {
+                        "lang": "painless",
+                        "source": """
+                            def time = params['_source']['data']['time'];
+            
+                            if(time != null) {
+                                if(time.length == 0) {
+                                    emit("NONE");
+                                } else if(time.length == 1) {
+                                    emit("TIMESTAMP");
+                                } else if (time.length == 2) {
+                                    emit("TIME_INTERVAL");
+                                } else {
+                                    emit("UNKNOWN");
+                                }
+                            } else {
+                                emit("NONE");
                             }
                         """
                     }
@@ -69,7 +94,7 @@ class Utils:
                             String[] split_file_name = file_name.splitOnToken('--');
 
                             if(split_file_name.length == 1) {{
-                                emit('NULL');
+                                emit('NONE');
                             }} else {{
                                 String surface_content = split_file_name[1].replace('{OBJECT_TYPES[object_type]}', '');
                                 emit(surface_content);
@@ -79,41 +104,24 @@ class Utils:
                 }
             },
             "query": {
-                "bool": {
-                    "must": [
-                        {"match": {"class": object_type}}
-                    ],
-                    "must_not": []
-                }
+                "bool": {}
             },
             "fields": ["tag_name", "time_interval"]
         }
 
-        if aggregate_field in ["tag_name", "time_interval"]:
-            elastic_query["query"]["bool"]["must_not"].append(
-                {"term": {aggregate_field: "NULL"}}
-            )
-
-        if include_time_data != TimeData.ALL:
-            term = {"term": {"time_interval": "NULL"}}
-
-            if include_time_data == TimeData.NO_TIMEDATA:
-                elastic_query["query"]["bool"]["must"].append(term)
-            elif include_time_data == TimeData.ONLY_TIMEDATA:
-                elastic_query["query"]["bool"]["must_not"].append(term)
-            else:
-                raise ValueError(f"Invalid value for include_time_data: {include_time_data}")
+        must = [{"match": {"class": object_type}}]
+        must_not = []
 
         if sort:
             elastic_query["sort"] = sort
 
         for field in terms:
-            elastic_query["query"]["bool"]["must"].append({
+            must.append({
                 "terms": {field: terms[field]}
             })
 
         for field in fields_exists:
-            elastic_query["query"]["bool"]["must"].append({
+            must.append({
                 "exists": { "field": field}
             })
 
@@ -126,5 +134,36 @@ class Utils:
                     }
                 }
             }
+
+        if aggregate_field in ["tag_name", "time_interval"]:
+            must_not.append({
+                "term": {aggregate_field: "NONE"}
+            })
+
+        if include_time_data is not None:
+            if include_time_data == TimeData.ALL:
+                must.append({
+                    "terms": {"time_type": ["TIMESTAMP", "TIME_INTERVAL"]}
+                })
+            elif include_time_data == TimeData.TIMESTAMP:
+                must.append({
+                    "term": {"time_type": "TIMESTAMP"}
+                })
+            elif include_time_data == TimeData.TIME_INTERVAL:
+                must.append({
+                    "term": {"time_type": "TIME_INTERVAL"}
+                })
+            elif include_time_data == TimeData.NONE:
+                must_not.append({
+                    "terms": {"time_type": ["TIMESTAMP", "TIME_INTERVAL"]}
+                })
+            else:
+                raise ValueError(f"Invalid value for include_time_data: {include_time_data}")
+
+        if len(must) > 0:
+            elastic_query["query"]["bool"]["must"] = must
+
+        if len(must_not) > 0:
+            elastic_query["query"]["bool"]["must_not"] = must_not
 
         return elastic_query

--- a/src/fmu/sumo/explorer/_utils.py
+++ b/src/fmu/sumo/explorer/_utils.py
@@ -101,6 +101,8 @@ class Utils:
                 elastic_query["query"]["bool"]["must"].append(term)
             elif include_time_data == TimeData.ONLY_TIMEDATA:
                 elastic_query["query"]["bool"]["must_not"].append(term)
+            else:
+                raise ValueError(f"Invalid value for include_time_data: {include_time_data}")
 
         if sort:
             elastic_query["sort"] = sort

--- a/src/fmu/sumo/explorer/_utils.py
+++ b/src/fmu/sumo/explorer/_utils.py
@@ -1,5 +1,19 @@
 from enum import Enum
 
+class ObjectType(str, Enum):
+    SURFACE = "surface"
+    POLYGONS = "polyons"
+    TABLE = "table"
+    
+class Property(str, Enum):
+    TAG_NAME = "tag_name"
+    TIME_INTERVAL = "time_interval"
+    TIME_TYPE = "time_type"
+    AGGREGATION = "aggregation"
+    OBJECT_NAME = "object_name"
+    ITERATION_ID = "iteration_id"
+    REALIZATION_ID = "realization_id"
+
 class TimeData(str, Enum):
     ALL = "ALL"
     TIMESTAMP = "TIMESTAMP"

--- a/src/fmu/sumo/explorer/_utils.py
+++ b/src/fmu/sumo/explorer/_utils.py
@@ -1,5 +1,5 @@
 from enum import Enum
-class TimeData(Enum):
+class TimeData(str, Enum):
     ALL = "ALL"
     ONLY_TIMEDATA = "ONLY_TIMEDATA"
     NO_TIMEDATA = "NO_TIMEDATA"


### PR DESCRIPTION
Added a new `include_time_data` parameter in `Case.get_objects` and `Case.get_object_property_values`. This lets you filter on time data.

The `include_time_data` parameter is of type `TimeData`, an enum with four values: `ALL`, `TIMESTAMP`, `TIME_INTERVAL` and `NONE`.

Simple example:
```python
from fmu.sumo.explorer import Explorer, TimeData

sumo = Explorer(env="dev")
case = sumo.get_case_by_id("81a57a32-37e7-06bc-924e-6710ba6e59b0")

# Get all objects, regardless of time data
objects = case.get_objects(
    "surface", 
    iteration_ids=[0], 
    realization_ids=[0]
)

print(len(objects)) 
# output: 920

# Get objects with all types of time data
objects = case.get_objects(
    "surface", 
    iteration_ids=[0], 
    realization_ids=[0], 
    include_time_data=TimeData.ALL # <-
)

print(len(objects))
# output: 741

# Get objects with timestamps
objects = case.get_objects(
    "surface", 
    iteration_ids=[0], 
    realization_ids=[0], 
    include_time_data=TimeData.TIMESTAMP # <-
)

print(len(objects))
# output: 151

# Get objects with time intervals
objects = case.get_objects(
    "surface", 
    iteration_ids=[0], 
    realization_ids=[0], 
    include_time_data=TimeData.TIME_INTERVAL # <-
)

print(len(objects))
# output 590

# Get objects with no time data
objects = case.get_objects(
    "surface", 
    iteration_ids=[0], 
    realization_ids=[0], 
    include_time_data=TimeData.NONE
)

print(len(objects))
# output 179
```