### PR TITLE
Let `prod` be default when initializing the Explorer.

### DIFF
--- a/src/fmu/sumo/explorer/explorer.py
+++ b/src/fmu/sumo/explorer/explorer.py
@@ -28,7 +28,7 @@ class Explorer:
 
     """
 
-    def __init__(self, env, token=None, interactive=True):
+    def __init__(self, env="prod", token=None, interactive=True):
         """Initialize the Explorer class."""
         self._env = env
         self.utils = Utils()


### PR DESCRIPTION
Let `prod` be default when initializing the Explorer.