### PR TITLE
Add case.iterations property++

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ _venv
 
 # setuptools_scm version
 src/fmu/sumo/version.py
+
+# local expermentation
+testing.ipynb

--- a/src/fmu/sumo/explorer/objects/document_collection.py
+++ b/src/fmu/sumo/explorer/objects/document_collection.py
@@ -29,9 +29,7 @@ class DocumentCollection:
             Document collection size
         """
         if self._len is None:
-            query = {"query": self._query, "size": 0}
-            res = self._sumo.post("/search", json=query)
-            self._len = res.json()["hits"]["total"]["value"]
+            self._len = self._utils.get_doc_count(self._query)
 
         return self._len
 
@@ -68,7 +66,8 @@ class DocumentCollection:
             A List of unique values for the given field
         """
         if field not in self._field_values:
-            self._field_values[field] = self._utils.get_buckets(field, self._query)
+            buckets = self._utils.get_buckets(field, self._query)
+            self._field_values[field] = list(map(lambda bucket: bucket["key"], buckets))
 
         return self._field_values[field]
 
@@ -81,7 +80,7 @@ class DocumentCollection:
         query = {
             "query": self._query,
             "sort": [{"_doc": {"order": "desc"}}],
-            "size": 50,
+            "size": 500,
         }
 
         if self._after is not None:

--- a/src/fmu/sumo/explorer/utils.py
+++ b/src/fmu/sumo/explorer/utils.py
@@ -27,7 +27,7 @@ class Utils:
         """
         query = {
             "size": 0,
-            "aggs": {f"{field}": {"terms": {"field": field, "size": 50}}},
+            "aggs": {f"{field}": {"terms": {"field": field, "size": 2000}}},
             "query": query,
         }
 
@@ -37,7 +37,23 @@ class Utils:
         res = self._sumo.post("/search", json=query)
         buckets = res.json()["aggregations"][field]["buckets"]
 
-        return list(map(lambda bucket: bucket["key"], buckets))
+        return buckets
+    
+    def get_doc_count(self, query: Dict) -> int:
+        query = {
+            "size": 0,
+            "aggs": {"class": {"terms": {"field": "class.keyword", "size": 100}}},
+            "query": query
+        }
+
+        res = self._sumo.post("/search", json=query)
+        buckets = res.json()["aggregations"]["class"]["buckets"]
+        count = 0 
+
+        for bucket in buckets:
+            count += bucket["doc_count"]
+
+        return count
 
     def get_objects(
         self,


### PR DESCRIPTION
New `Case` property: `iterations`. Returns a list of dictionaries with iteration information:

```python
case.iterations

[
    {'id': 1, 'name': 'iter-1', 'realizations': 100},
    {'id': 0, 'name': 'iter-0', 'realizations': 100}
]
```

Additional stuff:

- Changed the way we get the `len` of a `DocumentCollection` so it returns accurate counts of collections larger than 10 000
- Increased the bucket size when doing term aggregations from 50 -> 2000
- Increased the document batch size from 50 -> 500