### PR TITLE
Case realizations and uuid filtering

### DIFF
--- a/src/fmu/sumo/explorer/objects/_child_collection.py
+++ b/src/fmu/sumo/explorer/objects/_child_collection.py
@@ -65,6 +65,7 @@ class ChildCollection(DocumentCollection):
         stage: Union[str, List[str], bool] = None,
         column: Union[str, List[str], bool] = None,
         time: TimeFilter = None,
+        uuid: Union[str, List[str], bool] = None,
     ):
         must = []
         must_not = []
@@ -77,6 +78,7 @@ class ChildCollection(DocumentCollection):
             "fmu.aggregation.operation.keyword": aggregation,
             "fmu.context.stage.keyword": stage,
             "data.spec.columns.keyword": column,
+            "_id": uuid,
         }
 
         for prop in prop_map:

--- a/src/fmu/sumo/explorer/objects/case.py
+++ b/src/fmu/sumo/explorer/objects/case.py
@@ -87,6 +87,33 @@ class Case(Document):
 
         return self._iterations
 
+    def get_realizations(self, iteration: str = None) -> List[int]:
+        """Get a list of realization ids
+
+        Calling this method without the iteration argument will
+        return a list of unique realization ids across iterations.
+        It is not guaranteed that all realizations in this list exists
+        in all case iterations.
+
+        Args:
+            iteration (str): iteration name
+
+        Returns:
+            List[int]: realization ids
+        """
+        must = [{"term": {"_sumo.parent_object.keyword": self.uuid}}]
+
+        if iteration:
+            must.append({"term": {"fmu.iteration.name.keyword": iteration}})
+
+        buckets = self._utils.get_buckets(
+            "fmu.realization.id",
+            query={"bool": {"must": must}},
+            sort=["fmu.realization.id"],
+        )
+
+        return list(map(lambda b: b["key"], buckets))
+
     @property
     def surfaces(self) -> SurfaceCollection:
         """List of case surfaces"""

--- a/src/fmu/sumo/explorer/objects/polygons_collection.py
+++ b/src/fmu/sumo/explorer/objects/polygons_collection.py
@@ -20,6 +20,7 @@ class PolygonsCollection(ChildCollection):
         tagname: Union[str, List[str], bool] = None,
         iteration: Union[str, List[str], bool] = None,
         realization: Union[int, List[int], bool] = None,
+        uuid: Union[str, List[str], bool] = None,
     ) -> "PolygonsCollection":
         """Filter polygons
 
@@ -28,6 +29,7 @@ class PolygonsCollection(ChildCollection):
             tagname (Union[str, List[str], bool]): polygon tagname
             iteration (Union[int, List[int], bool]): iteration id
             realization Union[int, List[int], bool]: realization id
+            uuid (Union[str, List[str], bool]): polygons object uuid
 
         Returns:
             PolygonsCollection: A filtered PolygonsCollection
@@ -37,5 +39,6 @@ class PolygonsCollection(ChildCollection):
             tagname=tagname,
             iteration=iteration,
             realization=realization,
+            uuid=uuid,
         )
         return PolygonsCollection(self._sumo, self._case_uuid, query)

--- a/src/fmu/sumo/explorer/objects/surface_collection.py
+++ b/src/fmu/sumo/explorer/objects/surface_collection.py
@@ -97,6 +97,7 @@ class SurfaceCollection(ChildCollection):
         aggregation: Union[str, List[str], bool] = None,
         stage: Union[str, List[str], bool] = None,
         time: TimeFilter = None,
+        uuid: Union[str, List[str], bool] = None,
     ) -> "SurfaceCollection":
         """Filter surfaces
 
@@ -110,6 +111,7 @@ class SurfaceCollection(ChildCollection):
             aggregation (Union[str, List[str], bool]): aggregation operation
             stage (Union[str, List[str], bool]): context/stage
             time (TimeFilter): time filter
+            uuid (Union[str, List[str], bool]): surface object uuid
 
         Returns:
             SurfaceCollection: A filtered SurfaceCollection
@@ -157,6 +159,7 @@ class SurfaceCollection(ChildCollection):
             aggregation=aggregation,
             stage=stage,
             time=time,
+            uuid=uuid,
         )
 
         return SurfaceCollection(self._sumo, self._case_uuid, query)

--- a/src/fmu/sumo/explorer/objects/table_collection.py
+++ b/src/fmu/sumo/explorer/objects/table_collection.py
@@ -28,6 +28,7 @@ class TableCollection(ChildCollection):
         aggregation: Union[str, List[str], bool] = None,
         stage: Union[str, List[str], bool] = None,
         column: Union[str, List[str], bool] = None,
+        uuid: Union[str, List[str], bool] = None,
     ) -> "TableCollection":
         """Filter tables
 
@@ -38,6 +39,7 @@ class TableCollection(ChildCollection):
             realization Union[int, List[int], bool]: realization id
             aggregation (Union[str, List[str], bool]): aggregation operation
             stage (Union[str, List[str], bool]): context/stage
+            uuid (Union[str, List[str], bool]): table object uuid
 
         Returns:
             TableCollection: A filtered TableCollection
@@ -51,5 +53,6 @@ class TableCollection(ChildCollection):
             aggregation=aggregation,
             stage=stage,
             column=column,
+            uuid=uuid,
         )
         return TableCollection(self._sumo, self._case_uuid, query)


### PR DESCRIPTION
Added `Case.get_realizations` method, returns a list of realization ids.

Also added a `uuid` parameter to the `[object_type].filter` methods.