### PR TITLE
use wrapper method to get aggregates

### DIFF
--- a/src/fmu/sumo/explorer/objects/surface_collection.py
+++ b/src/fmu/sumo/explorer/objects/surface_collection.py
@@ -86,9 +86,8 @@ class SurfaceCollection(ChildCollection):
             objects = self._utils.get_objects(500, self._query, ["_id"])
             object_ids = list(map(lambda obj: obj["_id"], objects))
 
-            res = self._sumo.post(
-                "/aggregate",
-                json={"operation": [operation], "object_ids": object_ids},
+            res = self._sumo.get_aggregate(
+                json={"operation": [operation], "object_ids": object_ids}
             )
 
             self._aggregation_cache[operation] = xtgeo.surface_from_file(

--- a/src/fmu/sumo/explorer/objects/surface_collection.py
+++ b/src/fmu/sumo/explorer/objects/surface_collection.py
@@ -82,6 +82,8 @@ class SurfaceCollection(ChildCollection):
         return intervals
 
     def _aggregate(self, operation: str) -> xtgeo.RegularSurface:
+        if not self._sumo.aggregation_enabled:
+            raise Exception("Failed creating aggregation client.")
         if operation not in self._aggregation_cache:
             objects = self._utils.get_objects(500, self._query, ["_id"])
             object_ids = list(map(lambda obj: obj["_id"], objects))


### PR DESCRIPTION
* Use method from wrapper to get aggregates instead of the deprecated /aggregate endpoint.
* Raise exception when trying to get aggregate and failed to create aggregation client.

Dependent on change in python wrapper: https://github.com/equinor/sumo-wrapper-python/pull/131