### PR TITLE
read table based on format

### DIFF
--- a/src/fmu/sumo/explorer/objects/table.py
+++ b/src/fmu/sumo/explorer/objects/table.py
@@ -28,10 +28,12 @@ class Table(Child):
             DataFrame: A DataFrame object
         """
         if not self._dataframe:
-            try:
+            if self.format == "arrow":
                 self._dataframe = pd.read_parquet(self.blob)
-            except UnicodeDecodeError:
+            elif self.format == "csv":
                 self._dataframe = pd.read_csv(self.blob)
+            else:
+                raise Exception(f"Unknown format: {self.format}")
 
         return self._dataframe
 


### PR DESCRIPTION
Fixes a bug where `csv` files are not read properly.
Exception is `ArrowInvalid: Could not open Parquet input source '<Buffer>': Parquet magic bytes not found in footer. Either the file is corrupted or this is not a parquet file.` and so not caught by the catch.