### PR TITLE
Fix table read

### DIFF
--- a/src/fmu/sumo/explorer/objects/table.py
+++ b/src/fmu/sumo/explorer/objects/table.py
@@ -56,22 +56,21 @@ class Table(Child):
                     worked = "csv"
 
                 except UnicodeDecodeError as ud_e:
-                    raise UnicodeDecodeError("Maybe not pandas?") from ud_e
+                    raise UnicodeDecodeError("Maybe not csv?") from ud_e
             else:
                 try:
                     worked = "feather"
                     self._dataframe = pf.read_feather(self.blob)
                 except pa.lib.ArrowInvalid:
                     try:
-                        self._dataframe = pd.read_csv(self.blob)
+                        worked = "parquet"
+                        self._dataframe = pd.read_parquet(self.blob)
 
                     except UnicodeDecodeError as ud_error:
                         raise TypeError(
                             "Come on, no way this is converting to pandas!!"
                         ) from ud_error
 
-                    worked = "parquet"
-                self._dataframe = pd.read_parquet(self.blob)
         self._logger.debug("Read blob as %s to return pandas", worked)
         return self._dataframe
 

--- a/src/fmu/sumo/explorer/objects/table.py
+++ b/src/fmu/sumo/explorer/objects/table.py
@@ -32,7 +32,6 @@ class Table(Child):
         Returns:
             DataFrame: A DataFrame object
         """
-<<<<<<< Updated upstream
         warn(
             ".dataframe is deprecated, renamed to .to_pandas",
             DeprecationWarning,
@@ -47,17 +46,11 @@ class Table(Child):
         Returns:
             DataFrame: A DataFrame object
         """
-        if not self._dataframe:
-            try:
-                self._dataframe = pd.read_parquet(self.blob)
 
-            except pa.lib.ArrowInvalid:
-=======
         if self._dataframe is None:
             if self["data"]["format"] == "csv":
                 worked = "csv"
                 self._logger.debug("Treating blob as csv")
->>>>>>> Stashed changes
                 try:
                     self._dataframe = pd.read_csv(self.blob)
                     worked = "csv"
@@ -69,7 +62,6 @@ class Table(Child):
                     worked = "feather"
                     self._dataframe = pf.read_feather(self.blob)
                 except pa.lib.ArrowInvalid:
-<<<<<<< Updated upstream
                     try:
                         self._dataframe = pd.read_csv(self.blob)
 
@@ -78,11 +70,9 @@ class Table(Child):
                             "Come on, no way this is converting to pandas!!"
                         ) from ud_error
 
-=======
                     worked = "parquet"
                 self._dataframe = pd.read_parquet(self.blob)
         self._logger.debug("Read blob as %s to return pandas", worked)
->>>>>>> Stashed changes
         return self._dataframe
 
     @to_pandas.setter
@@ -96,7 +86,6 @@ class Table(Child):
         Returns:
             pa.Table: _description_
         """
-<<<<<<< Updated upstream
         warn(
             ".arrowtable is deprecated, renamed to .to_arrow",
             DeprecationWarning,
@@ -112,14 +101,8 @@ class Table(Child):
         Returns:
             pa.Table: _description_
         """
-        if not self._arrowtable:
-            try:
-                self._arrowtable = pq.read_table(self.blob)
-            except pa.lib.ArrowInvalid:
-=======
         if self._arrowtable is None:
             if self["data"]["format"] == "arrow":
->>>>>>> Stashed changes
                 try:
                     worked = "feather"
                     self._arrowtable = pf.read_table(self.blob)
@@ -127,7 +110,7 @@ class Table(Child):
                     worked = "parquet"
                     self._arrowtable = pq.read_table(self.blob)
             else:
-                self._logger.warning(
+                warn(
                     "Reading csv format into arrow, you will not get the full benefit of native arrow"
                 )
                 worked = "csv"

--- a/tests/test_aggregated_table.py
+++ b/tests/test_aggregated_table.py
@@ -53,9 +53,7 @@ def test_aggregated_summary_arrow_with_deprecated_function_name(
         DeprecationWarning,
         match=".arrowtable is deprecated, renamed to .to_arrow",
     ):
-        column.arrowtable
-
-    assert isinstance(column.arrowtable, pa.Table)
+        assert isinstance(column.arrowtable, pa.Table)
     with pytest.raises(IndexError) as e_info:
         table = table["banana"]
         assert (

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1,0 +1,65 @@
+from fmu.sumo.explorer import Explorer
+import pytest
+
+
+@pytest.fixture(name="doc", scope="function")
+def _fixture_doc():
+    exp = Explorer("dev")
+    case = exp.get_case_by_uuid("8575ed9a-b0c1-4f64-b9ab-fab9cec31f4a")
+    pvt_table = case.tables.filter(
+        name="SNORRE",
+        tagname="pvt",
+        iteration="iter-0",
+        realization=113,
+    )
+    return pvt_table[0]
+
+
+@pytest.fixture(name="correct_columns", scope="session")
+def _fixture_cols():
+    return [
+        "PRESSURE",
+        "VOLUMEFACTOR",
+        "VISCOSITY",
+        "RS",
+        "PVTNUM",
+        "KEYWORD",
+        "OILDENSITY",
+        "WATERDENSITY",
+        "GASDENSITY",
+        "COMPRESSIBILITY",
+        "VISCOSIBILITY",
+    ]
+
+
+def test_to_pandas_with_csv(doc, correct_columns):
+    """Test method to_pandas
+
+    Args:
+        doc (fmu.sumo.Document): the document to read from
+        correct_columns (list): list of correct columns
+    """
+    returned = doc.to_pandas
+    check_columns = returned.columns.tolist()
+    correct_columns.sort()
+    check_columns.sort()
+    assert (
+        check_columns == correct_columns
+    ), f"Cols should be {correct_columns}, {check_columns}, when csv"
+
+
+def test_to_arrow_with_csv(doc, correct_columns):
+    """Test method to_arrow
+
+    Args:
+        doc (fmu.sumo.Document): the document to read from
+        correct_columns (list): list of correct columns
+    """
+    returned = doc.to_arrow
+    correct_columns.sort()
+    check_columns = returned.column_names
+    check_columns.sort()
+
+    assert (
+        check_columns == correct_columns
+    ), f"Cols should be {correct_columns}, {check_columns}, when arrow"


### PR DESCRIPTION
Ensure that csv objects are read as csv, pyarrow.parquet seems to be able to read these, causing havoc