### PR TITLE
Remove `logging.NullHandler`

### DIFF
--- a/src/fmu/sumo/explorer/objects/table.py
+++ b/src/fmu/sumo/explorer/objects/table.py
@@ -8,8 +8,6 @@ from sumo.wrapper import SumoClient
 from fmu.sumo.explorer.objects._child import Child
 from warnings import warn
 
-logging.basicConfig(handlers=logging.NullHandler)
-
 
 class Table(Child):
     """Class representing a table object in Sumo"""


### PR DESCRIPTION
Closes #181.

Below snippet is copied from https://docs.python.org/3/howto/logging.html. Based on that I would argue it is better in this case to use default Python behavior in this case (i.e. not impose a `NullHandler`).

> If for some reason you don’t want these messages printed in the absence of any logging configuration, you can attach a do-nothing handler to the top-level logger for your library. This avoids the message being printed, since a handler will always be found for the library’s events: it just doesn’t produce any output. If the library user configures logging for application use, presumably that configuration will add some handlers, and if levels are suitably configured then logging calls made in library code will send output to those handlers, as normal.
> 
> A do-nothing handler is included in the logging package: [NullHandler](https://docs.python.org/3/library/logging.handlers.html#logging.NullHandler) (since Python 3.1). An instance of this handler could be added to the top-level logger of the logging namespace used by the library (if you want to prevent your library’s logged events being output to sys.stderr in the absence of logging configuration).