### PR TITLE
install wrapper from pypi

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 PyYAML>=5.4
 pandas>=1.1.3
 deprecation
-sumo-wrapper-python @ git+https://github.com/equinor/sumo-wrapper-python.git@main#egg=sumo-wrapper-python
+sumo-wrapper-python
 xtgeo
 azure-core
 pyarrow; python_version > "3.6.1"


### PR DESCRIPTION
Can not have requirement using direct url when publishing to PyPi.