### PR TITLE
remove sphinx-togglebutton

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,10 +26,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.autodoc",
     "sphinx_autodoc_typehints",
-    "sphinx_togglebutton",
 ]
-
-togglebutton_hint = "Expand"
 
 autodoc_mock_imports = [
     "ert",

--- a/requirements/requirements_docs.txt
+++ b/requirements/requirements_docs.txt
@@ -3,4 +3,3 @@ sphinx-rtd-theme
 autoapi
 sphinx-autodoc-typehints
 sphinxcontrib-apidoc
-sphinx-togglebutton


### PR DESCRIPTION
`sphinx-togglebutton` is the source of some vulnerabilities reported by snyk.
Can't see that it is actually used anywhere so trying to just remove it.