### PR TITLE
Always sim2sumo

### DIFF
--- a/src/fmu/sumo/utilities/sim2sumo.py
+++ b/src/fmu/sumo/utilities/sim2sumo.py
@@ -278,6 +278,12 @@ def read_config(config):
         logger.info("No special options selected")
         options = {}
     options["arrow"] = options.get("arrow", True)
+    logger.info(
+        "Running with: datafile(s): \n%s \n Types: \n %s \noptions:\n %s",
+        datafiles,
+        submods,
+        options,
+    )
     return datafiles, submods, options
 
 

--- a/src/fmu/sumo/utilities/sim2sumo.py
+++ b/src/fmu/sumo/utilities/sim2sumo.py
@@ -294,6 +294,7 @@ def export_with_config(config_path):
         datafiles, submods, options = read_config(yaml_load(config_path))
         for datafile in datafiles:
             for submod in submods:
+                logger.info("Exporting %s", submod)
                 export_path = export_results(
                     datafile,
                     submod,

--- a/src/fmu/sumo/utilities/sim2sumo.py
+++ b/src/fmu/sumo/utilities/sim2sumo.py
@@ -15,8 +15,6 @@ import yaml
 from fmu.dataio import ExportData
 from fmu.sumo.uploader.scripts.sumo_upload import sumo_upload_main
 
-logging.basicConfig(level="INFO")
-
 
 def yaml_load(file_name):
     """Load yaml config file into dict

--- a/src/fmu/sumo/utilities/sim2sumo.py
+++ b/src/fmu/sumo/utilities/sim2sumo.py
@@ -163,6 +163,9 @@ def get_results(
             trace = sys.exc_info()[1]
         except FileNotFoundError:
             trace = sys.exc_info()[1]
+        except ValueError:
+            trace = sys.exc_info()[1]
+
         if trace is not None:
             logger.warning(
                 "Trace: %s, \nNo results produced ",

--- a/src/fmu/sumo/utilities/sim2sumo.py
+++ b/src/fmu/sumo/utilities/sim2sumo.py
@@ -180,7 +180,7 @@ def tidy():
             unwanted_posix.unlink()
 
 
-def export_csv(
+def export_results(
     datafile_path: str,
     submod: str,
     config_file="fmuconfig/output/global_variables.yml",
@@ -285,7 +285,7 @@ def export_with_config(config_path):
         datafiles, submods, options = read_config(yaml_load(config_path))
         for datafile in datafiles:
             for submod in submods:
-                export_path = export_csv(
+                export_path = export_results(
                     datafile,
                     submod,
                     config_file=config_path,

--- a/tests/data/reek/realization-0/iter-0/fmuconfig/output/global_variables_w_eclpath_and_extras.yml
+++ b/tests/data/reek/realization-0/iter-0/fmuconfig/output/global_variables_w_eclpath_and_extras.yml
@@ -31,7 +31,7 @@ sim2sumo:
     - grid
     - rft
   options:
-    arrow: true
+    arrow: false
     time_index: daily,
     start_date: 2002-01-02
     end_date: 2003-01-02

--- a/tests/test_utility_sim2sumo.py
+++ b/tests/test_utility_sim2sumo.py
@@ -82,7 +82,7 @@ def test_export_csv(tmp_path, submod):
         tmp_path / f"share/results/tables/{REEK_BASE}--{submod}.csv".lower()
     )
     meta_path = export_path.parent / f".{export_path.name}.yml"
-    actual_path = sim2sumo.export_csv(
+    actual_path = sim2sumo.export_results(
         REEK_DATA_FILE,
         submod,
         CONFIG_PATH,
@@ -109,7 +109,7 @@ def test_export_csv_w_options(tmp_path, submod="summary"):
     }
 
     meta_path = export_path.parent / f".{export_path.name}.yml"
-    actual_path = sim2sumo.export_csv(
+    actual_path = sim2sumo.export_results(
         REEK_DATA_FILE, submod, CONFIG_PATH, **key_args
     )
     LOGGER.info(actual_path)

--- a/tests/test_utility_sim2sumo.py
+++ b/tests/test_utility_sim2sumo.py
@@ -136,7 +136,7 @@ CHECK_DICT = {
         "nrdatafile": 1,
         "nrsubmods": 3,
         "nroptions": 4,
-        "arrow": True,
+        "arrow": False,
     },
     "global_variables.yml": {
         "nrdatafile": 2,

--- a/tests/test_utility_sim2sumo.py
+++ b/tests/test_utility_sim2sumo.py
@@ -137,7 +137,7 @@ CHECK_DICT = {
     },
     "global_variables.yml": {
         "nrdatafile": 2,
-        "nrsubmods": 16,
+        "nrsubmods": 3,
         "nroptions": 1,
         "arrow": False,
     },
@@ -166,7 +166,7 @@ def test_read_config(config_path):
     """Test reading of config file via read_config function"""
     os.chdir(REEK_REAL)
     LOGGER.info(config_path)
-    config = sim2sumo.yaml_load(config_path)["sim2sumo"]
+    config = sim2sumo.yaml_load(config_path)
     assert isinstance(config, (dict, bool))
     dfiles, submods, opts = sim2sumo.read_config(config)
     name = config_path.name

--- a/tests/test_utility_sim2sumo.py
+++ b/tests/test_utility_sim2sumo.py
@@ -56,16 +56,16 @@ def test_submodules_dict():
     (name for name in sim2sumo.SUBMODULES if name != "wellcompletiondata"),
 )
 # Skipping wellcompletion data, since this needs zonemap, which none of the others do
-def test_get_dataframe(submod):
+def test_get_results(submod):
     """Test fetching of dataframe"""
     extras = {}
     if submod == "wellcompletiondata":
         extras["zonemap"] = "data/reek/zones.lyr"
-    frame = sim2sumo.get_dataframe(REEK_DATA_FILE, submod)
+    frame = sim2sumo.get_results(REEK_DATA_FILE, submod)
     assert isinstance(
-        frame, pd.DataFrame
+        frame, pa.Table
     ), f"Call for get_dataframe should produce dataframe, but produces {type(frame)}"
-    frame = sim2sumo.get_dataframe(REEK_DATA_FILE, submod, arrow=True)
+    frame = sim2sumo.get_results(REEK_DATA_FILE, submod, arrow=True)
     assert isinstance(
         frame, pa.Table
     ), f"Call for get_dataframe with arrow=True should produce pa.Table, but produces {type(frame)}"
@@ -75,11 +75,11 @@ def test_get_dataframe(submod):
     "submod",
     (name for name in sim2sumo.SUBMODULES if name != "wellcompletiondata"),
 )
-def test_export_csv(tmp_path, submod):
+def test_export_results(tmp_path, submod):
     """Test writing of csv file"""
     os.chdir(tmp_path)
     export_path = (
-        tmp_path / f"share/results/tables/{REEK_BASE}--{submod}.csv".lower()
+        tmp_path / f"share/results/tables/{REEK_BASE}--{submod}.arrow".lower()
     )
     meta_path = export_path.parent / f".{export_path.name}.yml"
     actual_path = sim2sumo.export_results(
@@ -96,11 +96,11 @@ def test_export_csv(tmp_path, submod):
     assert meta_path.exists(), f"No export of metadata to {meta_path}"
 
 
-def test_export_csv_w_options(tmp_path, submod="summary"):
+def test_export_results_w_options(tmp_path, submod="summary"):
     """Test writing of csv file"""
     os.chdir(tmp_path)
     export_path = (
-        tmp_path / f"share/results/tables/{REEK_BASE}--{submod}.csv".lower()
+        tmp_path / f"share/results/tables/{REEK_BASE}--{submod}.arrow".lower()
     )
     key_args = {
         "time_index": "daily",
@@ -118,6 +118,9 @@ def test_export_csv_w_options(tmp_path, submod="summary"):
         str,
     ), "No string returned for path"
     assert export_path.exists(), f"No export of data to {export_path}"
+    assert "arrow" in str(
+        export_path
+    ), f"No arrow in path, should be, path is {export_path}"
     assert meta_path.exists(), f"No export of metadata to {meta_path}"
 
 
@@ -127,7 +130,7 @@ CHECK_DICT = {
         "nrdatafile": 1,
         "nrsubmods": 16,
         "nroptions": 1,
-        "arrow": False,
+        "arrow": True,
     },
     "global_variables_w_eclpath_and_extras.yml": {
         "nrdatafile": 1,
@@ -139,7 +142,7 @@ CHECK_DICT = {
         "nrdatafile": 2,
         "nrsubmods": 3,
         "nroptions": 1,
-        "arrow": False,
+        "arrow": True,
     },
 }
 
@@ -246,6 +249,13 @@ def test_export_w_config(tmp_path, config_path):
 #     path = f"/objects('{case_uuid}')"
 
 #     sumo.delete(path)
+
+
+def test_convert_to_arrow():
+    """Test function convert_to_arrow"""
+    dframe = pd.DataFrame([1, 2], columns=["a"])
+    table = sim2sumo.convert_to_arrow(dframe)
+    assert isinstance(table, pa.Table), "Did not convert to table"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Change code for sim2sumo utility such that no section sim2sumo in config file give upload of some standard types from simulator. These are for the time being summary, rft, and relative permeability (aka satfunc in sim2sumo speak)

With this change all the user wil have to do is add FORWARD_MODEL SIM2SUMO, and he or she will imedeately start uploading simulator results to sumo.

Also defaults to uploading arrow files, now user will have to specify arrow: false to not use arrow, then it changes to csv files