### PR TITLE
Explorer dictionary support

### DIFF
--- a/examples/explorer.ipynb
+++ b/examples/explorer.ipynb
@@ -318,7 +318,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.10.12"
   },
   "orig_nbformat": 4,
   "vscode": {

--- a/src/fmu/sumo/explorer/objects/case.py
+++ b/src/fmu/sumo/explorer/objects/case.py
@@ -6,6 +6,9 @@ from fmu.sumo.explorer.objects.surface_collection import SurfaceCollection
 from fmu.sumo.explorer.objects.polygons_collection import PolygonsCollection
 from fmu.sumo.explorer.objects.table_collection import TableCollection
 from fmu.sumo.explorer.objects.cube_collection import CubeCollection
+from fmu.sumo.explorer.objects.dictionary_collection import (
+    DictionaryCollection,
+)
 from fmu.sumo.explorer._utils import Utils
 from fmu.sumo.explorer.pit import Pit
 
@@ -54,12 +57,15 @@ class Case(Document):
                 "query": {"term": {"_sumo.parent_object.keyword": self.uuid}},
                 "aggs": {
                     "uuid": {
-                        "terms": {"field": "fmu.iteration.uuid.keyword", "size": 50},
+                        "terms": {
+                            "field": "fmu.iteration.uuid.keyword",
+                            "size": 50,
+                        },
                         "aggs": {
                             "name": {
                                 "terms": {
-                                    "field": "fmu.iteration.name.keyword", 
-                                    "size": 1
+                                    "field": "fmu.iteration.name.keyword",
+                                    "size": 1,
                                 }
                             },
                             "realizations": {
@@ -208,3 +214,8 @@ class Case(Document):
     def cubes(self) -> CubeCollection:
         """List of case tables"""
         return CubeCollection(self._sumo, self._uuid, pit=self._pit)
+
+    @property
+    def dictionaries(self) -> DictionaryCollection:
+        """List of case dictionaries"""
+        return DictionaryCollection(self._sumo, self._uuid, pit=self._pit)

--- a/src/fmu/sumo/explorer/objects/dictionary.py
+++ b/src/fmu/sumo/explorer/objects/dictionary.py
@@ -1,0 +1,36 @@
+"""Module containing class for polygons object"""
+import json
+from typing import Dict
+from sumo.wrapper import SumoClient
+from fmu.sumo.explorer.objects._child import Child
+
+
+class Dictionary(Child):
+    """Class representig a dictionary object in Sumo"""
+
+    _parsed: dict
+
+    def __init__(self, sumo: SumoClient, metadata: Dict) -> None:
+        """
+        Args:
+            sumo (SumoClient): connection to Sumo
+            metadata (dict): dictionary metadata
+        """
+        self._parsed = None
+
+        super().__init__(sumo, metadata)
+
+    @property
+    def blob(self) -> bytes:
+        """Object blob"""
+        if self._blob is None:
+            res = self._sumo.get(f"/objects('{self.uuid}')/blob")
+            self._blob = res
+
+        return self._blob
+
+    def parse(self) -> Dict:
+        if self._parsed is None:
+            self._parsed = json.loads(self.blob.decode("utf-8"))
+
+        return self._parsed

--- a/src/fmu/sumo/explorer/objects/dictionary.py
+++ b/src/fmu/sumo/explorer/objects/dictionary.py
@@ -1,4 +1,4 @@
-"""Module containing class for polygons object"""
+"""Module containing class for dictionary object"""
 import json
 from typing import Dict
 from sumo.wrapper import SumoClient

--- a/src/fmu/sumo/explorer/objects/dictionary_collection.py
+++ b/src/fmu/sumo/explorer/objects/dictionary_collection.py
@@ -1,0 +1,66 @@
+"""Module containing class for colection of polygons """
+from typing import Union, List, Dict
+from sumo.wrapper import SumoClient
+from fmu.sumo.explorer.objects._child_collection import ChildCollection
+from fmu.sumo.explorer.pit import Pit
+from fmu.sumo.explorer.objects.dictionary import Dictionary
+
+
+class DictionaryCollection(ChildCollection):
+    """Class for representing a collection of dictionaries objects in Sumo"""
+
+    def __init__(
+        self,
+        sumo: SumoClient,
+        case_uuid: str,
+        query: Dict = None,
+        pit: Pit = None,
+    ):
+        """
+        Args:
+            sumo (SumoClient): connection to Sumo
+            case_uuid (str): parent case uuid
+            query (dict): elastic query object
+            pit (Pit): point in time
+        """
+        super().__init__("dictionary", sumo, case_uuid, query, pit)
+
+    def __getitem__(self, index) -> Dictionary:
+        doc = super().__getitem__(index)
+        return Dictionary(self._sumo, doc)
+
+    def filter(
+        self,
+        name: Union[str, List[str], bool] = None,
+        tagname: Union[str, List[str], bool] = None,
+        iteration: Union[str, List[str], bool] = None,
+        realization: Union[int, List[int], bool] = None,
+        aggregation: Union[str, List[str], bool] = None,
+        stage: Union[str, List[str], bool] = None,
+        uuid: Union[str, List[str], bool] = None,
+    ) -> "DictionaryCollection":
+        """Filter dictionaries
+
+        Args:
+            name (Union[str, List[str], bool]): polygon name
+            tagname (Union[str, List[str], bool]): polygon tagname
+            iteration (Union[int, List[int], bool]): iteration id
+            realization Union[int, List[int], bool]: realization id
+            uuid (Union[str, List[str], bool]): polygons object uuid
+
+        Returns:
+            DictionaryCollection: A filtered DictionaryCollection
+        """
+        query = super()._add_filter(
+            name=name,
+            tagname=tagname,
+            iteration=iteration,
+            realization=realization,
+            aggregation=aggregation,
+            stage=stage,
+            uuid=uuid,
+        )
+
+        return DictionaryCollection(
+            self._sumo, self._case_uuid, query, self._pit
+        )

--- a/src/fmu/sumo/explorer/objects/dictionary_collection.py
+++ b/src/fmu/sumo/explorer/objects/dictionary_collection.py
@@ -1,4 +1,4 @@
-"""Module containing class for colection of polygons """
+"""Module containing class for colection of dictionaries """
 from typing import Union, List, Dict
 from sumo.wrapper import SumoClient
 from fmu.sumo.explorer.objects._child_collection import ChildCollection


### PR DESCRIPTION
Add support for retrieving files with `class:dictionary`.

## Examples:

### Get parameters file for a given realization
```python
dicts = my_case.dictionaries.filter(
    name="parameters",
    iteration="iter-0",
    realization=0
)

params = dicts[0]
```

### Get aggregated parameters
```python
dicts = my_case.dictionaries.filter(
    name="parameters",
    iteration="iter-4", 
    aggregation="collection",
)

param_names = dicts.tagnames

dicts = dicts.filter(tagname=param_names[0])
params = dicts[0]
```

### Get the dict object
```python
params.parse()
```