### PR TITLE
set minimum required python version to 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,9 +59,10 @@ setup(
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "Natural Language :: English",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     entry_points={
         "ert": [
@@ -77,7 +78,7 @@ setup(
     setup_requires=SETUP_REQUIREMENTS,
     test_suite="tests",
     extras_require=EXTRAS_REQUIRE,
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     packages=find_packages("src"),
     package_dir={"": "src"},
     include_package_data=True,


### PR DESCRIPTION
Snyk reports a vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2023-4863
Seems to be because Python <=3.7 ends up with Pillow@9.5.0. Python >=3.8 ends up with a non vulnerable Pillow@10.0.1.

Updating our project config should hopefully remove the Snyk report.
Also, komodo stable runs on Python 3.8 + Python 3.7 has reached EOL.