### PR TITLE
implement __iter__ and __aiter__ in DocumentCollection

### DIFF
--- a/src/fmu/sumo/explorer/explorer.py
+++ b/src/fmu/sumo/explorer/explorer.py
@@ -114,7 +114,7 @@ class Explorer:
             Case: case object
         """
         metadata = self._utils.get_object(uuid, _CASE_FIELDS)
-        return Case(self._sumo, metadata)
+        return Case(self._sumo, metadata, self._pit)
 
     async def get_case_by_uuid_async(self, uuid: str) -> Case:
         """Get case object by uuid
@@ -126,7 +126,7 @@ class Explorer:
             Case: case object
         """
         metadata = await self._utils.get_object_async(uuid, _CASE_FIELDS)
-        return Case(self._sumo, metadata)
+        return Case(self._sumo, metadata, self._pit)
 
     def get_surface_by_uuid(self, uuid: str) -> Surface:
         """Get surface object by uuid

--- a/src/fmu/sumo/explorer/objects/case_collection.py
+++ b/src/fmu/sumo/explorer/objects/case_collection.py
@@ -85,6 +85,10 @@ class CaseCollection(DocumentCollection):
         doc = super().__getitem__(index)
         return Case(self._sumo, doc, self._pit)
 
+    async def getitem_async(self, index: int) -> Case:
+        doc = await super().getitem_async(index)
+        return Case(self._sumo, doc)
+
     def filter(
         self,
         uuid: Union[str, List[str]] = None,

--- a/src/fmu/sumo/explorer/objects/cube_collection.py
+++ b/src/fmu/sumo/explorer/objects/cube_collection.py
@@ -1,5 +1,5 @@
 """Module containing class for collection of cubes """
-from typing import Union, List, Dict, Tuple
+from typing import Any, Coroutine, Union, List, Dict, Tuple
 from sumo.wrapper import SumoClient
 from fmu.sumo.explorer.objects._child_collection import ChildCollection
 from fmu.sumo.explorer.objects.cube import Cube
@@ -35,6 +35,10 @@ class CubeCollection(ChildCollection):
 
     def __getitem__(self, index) -> Cube:
         doc = super().__getitem__(index)
+        return Cube(self._sumo, doc)
+
+    async def getitem_async(self, index: int) -> Cube:
+        doc = await super().getitem_async(index)
         return Cube(self._sumo, doc)
 
     @property
@@ -129,7 +133,7 @@ class CubeCollection(ChildCollection):
         time: TimeFilter = None,
         uuid: Union[str, List[str], bool] = None,
         is_observation: bool = None,
-        is_prediction: bool = None
+        is_prediction: bool = None,
     ) -> "CubeCollection":
         """Filter cubes
 
@@ -156,7 +160,7 @@ class CubeCollection(ChildCollection):
             time=time,
             uuid=uuid,
             is_observation=is_observation,
-            is_prediction=is_prediction
+            is_prediction=is_prediction,
         )
 
         return CubeCollection(self._sumo, self._case_uuid, query, self._pit)

--- a/src/fmu/sumo/explorer/objects/cube_collection.py
+++ b/src/fmu/sumo/explorer/objects/cube_collection.py
@@ -1,5 +1,5 @@
 """Module containing class for collection of cubes """
-from typing import Any, Coroutine, Union, List, Dict, Tuple
+from typing import Union, List, Dict, Tuple
 from sumo.wrapper import SumoClient
 from fmu.sumo.explorer.objects._child_collection import ChildCollection
 from fmu.sumo.explorer.objects.cube import Cube

--- a/src/fmu/sumo/explorer/objects/dictionary_collection.py
+++ b/src/fmu/sumo/explorer/objects/dictionary_collection.py
@@ -1,5 +1,5 @@
 """Module containing class for colection of dictionaries """
-from typing import Any, Coroutine, Union, List, Dict
+from typing import Union, List, Dict
 from sumo.wrapper import SumoClient
 from fmu.sumo.explorer.objects._child_collection import ChildCollection
 from fmu.sumo.explorer.pit import Pit

--- a/src/fmu/sumo/explorer/objects/dictionary_collection.py
+++ b/src/fmu/sumo/explorer/objects/dictionary_collection.py
@@ -1,5 +1,5 @@
 """Module containing class for colection of dictionaries """
-from typing import Union, List, Dict
+from typing import Any, Coroutine, Union, List, Dict
 from sumo.wrapper import SumoClient
 from fmu.sumo.explorer.objects._child_collection import ChildCollection
 from fmu.sumo.explorer.pit import Pit
@@ -27,6 +27,10 @@ class DictionaryCollection(ChildCollection):
 
     def __getitem__(self, index) -> Dictionary:
         doc = super().__getitem__(index)
+        return Dictionary(self._sumo, doc)
+
+    async def getitem_async(self, index: int) -> Dictionary:
+        doc = await super().getitem_async(index)
         return Dictionary(self._sumo, doc)
 
     def filter(

--- a/src/fmu/sumo/explorer/objects/polygons_collection.py
+++ b/src/fmu/sumo/explorer/objects/polygons_collection.py
@@ -29,6 +29,10 @@ class PolygonsCollection(ChildCollection):
         doc = super().__getitem__(index)
         return Polygons(self._sumo, doc)
 
+    async def getitem_async(self, index: int) -> Polygons:
+        doc = await super().getitem_async(index)
+        return Polygons(self._sumo, doc)
+
     def filter(
         self,
         name: Union[str, List[str], bool] = None,

--- a/src/fmu/sumo/explorer/objects/surface_collection.py
+++ b/src/fmu/sumo/explorer/objects/surface_collection.py
@@ -41,6 +41,10 @@ class SurfaceCollection(ChildCollection):
         doc = super().__getitem__(index)
         return Surface(self._sumo, doc)
 
+    async def getitem_async(self, index: int) -> Surface:
+        doc = await super().getitem_async(index)
+        return Surface(self._sumo, doc)
+
     @property
     def timestamps(self) -> List[str]:
         """List of unique timestamps in SurfaceCollection"""
@@ -141,7 +145,9 @@ class SurfaceCollection(ChildCollection):
 
     async def _aggregate_async(self, operation: str) -> xtgeo.RegularSurface:
         if operation not in self._aggregation_cache:
-            objects = await self._utils.get_objects_async(500, self._query, ["_id"])
+            objects = await self._utils.get_objects_async(
+                500, self._query, ["_id"]
+            )
             object_ids = list(map(lambda obj: obj["_id"], objects))
 
             res = await self._sumo.post_async(

--- a/src/fmu/sumo/explorer/objects/table_collection.py
+++ b/src/fmu/sumo/explorer/objects/table_collection.py
@@ -29,6 +29,10 @@ class TableCollection(ChildCollection):
         doc = super().__getitem__(index)
         return Table(self._sumo, doc)
 
+    async def getitem_async(self, index: int) -> Table:
+        doc = await super().getitem_async(index)
+        return Table(self._sumo, doc)
+
     @property
     def columns(self) -> List[str]:
         """List of unique column names"""

--- a/src/fmu/sumo/explorer/pit.py
+++ b/src/fmu/sumo/explorer/pit.py
@@ -21,10 +21,13 @@ class Pit:
         res = self._sumo.post("/pit", params={"keep-alive": keep_alive})
         return res.json()["id"]
 
-    def get_pit_object(self) -> Dict:
+    def get_pit_object(self, pit_id: str = None) -> Dict:
         """Get the pit object
 
         Returns:
             Dict: dict with id and info about how long to keep alive
         """
-        return {"id": self._pit_id, "keep_alive": self._keep_alive}
+        return {
+            "id": pit_id if pit_id is not None else self._pit_id,
+            "keep_alive": self._keep_alive,
+        }


### PR DESCRIPTION
`DocumentCollection` can now be treated as an iterator and async iterator, enabling async iteration with the `async for .. in ..` syntax.

Some improvements in `pit` functionality:
- Use the updated pit id
- Pass `pit` to case returned by `Explorer.get_case_by_uuid` (bug fix) 

We are not deleting the `pit`, which is recommended. This is currently not possible because `SumoClient.delete` does not take params which is needed to call the `DELETE /api/v1/pit` endpoint. 

Closes #228 