### PR TITLE
More metadata

### DIFF
--- a/src/fmu/sumo/explorer/objects/_child_collection.py
+++ b/src/fmu/sumo/explorer/objects/_child_collection.py
@@ -6,30 +6,10 @@ from fmu.sumo.explorer.timefilter import TimeFilter
 from fmu.sumo.explorer.pit import Pit
 
 _CHILD_FIELDS = {
-    "include": [
-        "_id",
-        "data.name",
-        "data.content",
-        "data.tagname",
-        "data.time",
-        "data.format",
-        "data.bbox",
-        "data.spec",
-        "data.stratigraphic",
-        "data.vertical_domain",
-        "fmu.case.name",
-        "fmu.case.user.id",
-        "fmu.realization.id",
-        "fmu.iteration.name",
-        "fmu.context.stage",
-        "fmu.aggregation.operation",
-        "_sumo.status",
-        "access.asset",
-        "masterdata.smda.field",
-        "file.checksum_md5",
-        "file.relative_path",
-        "data.is_observation",
-        "data.is_prediction"
+    "include": [],
+    "exclude": [
+        "data.spec.columns",
+        "fmu.realization.parameters"
     ]
 }
 

--- a/src/fmu/sumo/explorer/objects/_child_collection.py
+++ b/src/fmu/sumo/explorer/objects/_child_collection.py
@@ -5,31 +5,33 @@ from fmu.sumo.explorer.objects._document_collection import DocumentCollection
 from fmu.sumo.explorer.timefilter import TimeFilter
 from fmu.sumo.explorer.pit import Pit
 
-_CHILD_FIELDS = [
-    "_id",
-    "data.name",
-    "data.content",
-    "data.tagname",
-    "data.time",
-    "data.format",
-    "data.bbox",
-    "data.spec",
-    "data.stratigraphic",
-    "data.vertical_domain",
-    "fmu.case.name",
-    "fmu.case.user.id",
-    "fmu.realization.id",
-    "fmu.iteration.name",
-    "fmu.context.stage",
-    "fmu.aggregation.operation",
-    "_sumo.status",
-    "access.asset",
-    "masterdata.smda.field",
-    "file.checksum_md5",
-    "file.relative_path",
-    "data.is_observation",
-    "data.is_prediction"
-]
+_CHILD_FIELDS = {
+    "include": [
+        "_id",
+        "data.name",
+        "data.content",
+        "data.tagname",
+        "data.time",
+        "data.format",
+        "data.bbox",
+        "data.spec",
+        "data.stratigraphic",
+        "data.vertical_domain",
+        "fmu.case.name",
+        "fmu.case.user.id",
+        "fmu.realization.id",
+        "fmu.iteration.name",
+        "fmu.context.stage",
+        "fmu.aggregation.operation",
+        "_sumo.status",
+        "access.asset",
+        "masterdata.smda.field",
+        "file.checksum_md5",
+        "file.relative_path",
+        "data.is_observation",
+        "data.is_prediction"
+    ]
+}
 
 
 class ChildCollection(DocumentCollection):

--- a/src/fmu/sumo/explorer/objects/case_collection.py
+++ b/src/fmu/sumo/explorer/objects/case_collection.py
@@ -6,14 +6,8 @@ from fmu.sumo.explorer.objects.case import Case
 from fmu.sumo.explorer.pit import Pit
 
 _CASE_FIELDS = {
-    "include": [
-        "_id",
-        "fmu.case.name",
-        "fmu.case.user.id",
-        "_sumo.status",
-        "access.asset",
-        "masterdata.smda.field",
-    ]
+    "include": [],
+    "exclude": []
 }
 
 

--- a/src/fmu/sumo/explorer/objects/case_collection.py
+++ b/src/fmu/sumo/explorer/objects/case_collection.py
@@ -5,14 +5,16 @@ from fmu.sumo.explorer.objects._document_collection import DocumentCollection
 from fmu.sumo.explorer.objects.case import Case
 from fmu.sumo.explorer.pit import Pit
 
-_CASE_FIELDS = [
-    "_id",
-    "fmu.case.name",
-    "fmu.case.user.id",
-    "_sumo.status",
-    "access.asset",
-    "masterdata.smda.field",
-]
+_CASE_FIELDS = {
+    "include": [
+        "_id",
+        "fmu.case.name",
+        "fmu.case.user.id",
+        "_sumo.status",
+        "access.asset",
+        "masterdata.smda.field",
+    ]
+}
 
 
 class CaseCollection(DocumentCollection):


### PR DESCRIPTION
Change metadata filtering, so that we can specify both "include" and "exclude" sets. This means that the `select` parameter should be a dictionary containing the keys `include` and/or `exclude`, both of which should be lists of attribute names. If one of these is specified as a an empty list, it is treated as missing.

It is also possible to specify `select` as a list; this will be treated the same as a dictionary with the list as the value of the "include" key.

The default value for `case` objects is to include everything, while for `child` objects, we exclude `data.spec.columns` and `fmu.realization.parameters`. 