### PR TITLE
267 to pandas as function

### DIFF
--- a/src/fmu/sumo/explorer/objects/table.py
+++ b/src/fmu/sumo/explorer/objects/table.py
@@ -35,9 +35,9 @@ class Table(Child):
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.to_pandas
+        return self.to_pandas()
 
-    @property
+
     def to_pandas(self) -> pd.DataFrame:
         """Return object as a pandas DataFrame
 
@@ -106,9 +106,6 @@ class Table(Child):
         self._logger.debug("Read blob as %s to return pandas", worked)
         return self._dataframe
 
-    @to_pandas.setter
-    def to_pandas(self, frame: pd.DataFrame):
-        self._dataframe = frame
 
     @property
     def arrowtable(self) -> pa.Table:

--- a/tests/test_objects_table.py
+++ b/tests/test_objects_table.py
@@ -23,6 +23,7 @@ def fixture_table(token: str, explorer: Explorer):
     case = explorer.cases.filter(name="drogon_ahm-2023-02-22")[0]
     return case.tables[0]
     
+### Table
 
 def test_table_dataframe(table):
     """Test the dataframe property."""
@@ -32,8 +33,8 @@ def test_table_dataframe(table):
 
 
 def test_table_to_pandas(table):
-    """Test the to_pandas property."""
-    df = table.to_pandas
+    """Test the to_pandas method."""
+    df = table.to_pandas()
     assert isinstance(df, pd.DataFrame)
 
 
@@ -49,6 +50,8 @@ def test_table_to_arrow(table):
     arrow = table.to_arrow()
     assert isinstance(arrow, pa.Table)
 
+
+### Aggregated Table
 
 def test_aggregated_summary_arrow(explorer: Explorer):
     """Test usage of Aggregated class with default type"""
@@ -96,18 +99,7 @@ def test_aggregated_summary_pandas(explorer: Explorer):
     """Test usage of Aggregated class with item_type=pandas"""
     case = explorer.cases.filter(name="drogon_ahm-2023-02-22")[0]
     table = AggregatedTable(case, "summary", "eclipse", "iter-0")
-    assert isinstance(table["FOPT"].to_pandas, pd.DataFrame)
-
-
-def test_aggregated_summary_pandas_with_deprecated_function_name(
-    explorer: Explorer,
-):
-    """Test usage of Aggregated class with item_type=pandas with deprecated function name"""
-    case = explorer.cases.filter(name="drogon_ahm-2023-02-22")[0]
-    table = AggregatedTable(case, "summary", "eclipse", "iter-0")
-    with pytest.warns(match=".dataframe is deprecated, renamed to .to_pandas()"):
-        mydata = table["FOPT"].dataframe
-    assert isinstance(mydata, pd.DataFrame)
+    assert isinstance(table["FOPT"].to_pandas(), pd.DataFrame)
 
 
 def test_get_fmu_iteration_parameters(explorer: Explorer):

--- a/tests/test_objects_table.py
+++ b/tests/test_objects_table.py
@@ -10,17 +10,22 @@ import pyarrow as pa
 from fmu.sumo.explorer import Explorer, AggregatedTable
 import pytest
 
+# Fixed test case ("Drogon_AHM_2023-02-22") in Sumo/DEV
+TESTCASE_UUID = "10f41041-2c17-4374-a735-bb0de62e29dc"
 
 @pytest.fixture(name="explorer")
 def fixture_explorer(token: str) -> Explorer:
     """Returns explorer"""
     return Explorer("dev", token=token)
 
+@pytest.fixture(name="case")
+def fixture_case(explorer: Explorer):
+    """Return fixed testcase."""
+    return explorer.get_case_by_uuid(TESTCASE_UUID)
 
 @pytest.fixture(name="table")
-def fixture_table(token: str, explorer: Explorer):
+def fixture_table(case):
     """Get one table for further testing."""
-    case = explorer.cases.filter(name="drogon_ahm-2023-02-22")[0]
     return case.tables[0]
     
 ### Table
@@ -53,10 +58,8 @@ def test_table_to_arrow(table):
 
 ### Aggregated Table
 
-def test_aggregated_summary_arrow(explorer: Explorer):
+def test_aggregated_summary_arrow(case):
     """Test usage of Aggregated class with default type"""
-
-    case = explorer.cases.filter(name="drogon_ahm-2023-02-22")[0]
 
     table = AggregatedTable(case, "summary", "eclipse", "iter-0")
 
@@ -71,12 +74,8 @@ def test_aggregated_summary_arrow(explorer: Explorer):
         )
 
 
-def test_aggregated_summary_arrow_with_deprecated_function_name(
-    explorer: Explorer,
-):
+def test_aggregated_summary_arrow_with_deprecated_function_name(case):
     """Test usage of Aggregated class with default type with deprecated function name"""
-
-    case = explorer.cases.filter(name="drogon_ahm-2023-02-22")[0]
 
     table = AggregatedTable(case, "summary", "eclipse", "iter-0")
 
@@ -95,15 +94,13 @@ def test_aggregated_summary_arrow_with_deprecated_function_name(
         )
 
 
-def test_aggregated_summary_pandas(explorer: Explorer):
+def test_aggregated_summary_pandas(case):
     """Test usage of Aggregated class with item_type=pandas"""
-    case = explorer.cases.filter(name="drogon_ahm-2023-02-22")[0]
     table = AggregatedTable(case, "summary", "eclipse", "iter-0")
     assert isinstance(table["FOPT"].to_pandas(), pd.DataFrame)
 
 
-def test_get_fmu_iteration_parameters(explorer: Explorer):
+def test_get_fmu_iteration_parameters(case):
     """Test getting the metadata of of an object"""
-    case = explorer.cases.filter(name="drogon_ahm-2023-02-22")[0]
     table = AggregatedTable(case, "summary", "eclipse", "iter-0")
     assert isinstance(table.parameters, dict)

--- a/tests/test_objects_table.py
+++ b/tests/test_objects_table.py
@@ -1,4 +1,10 @@
-"""Testing of Aggregated table class"""
+"""Test table objects.
+
+  * Table
+  * AggregatedTable
+  * TableCollection
+
+"""
 import pandas as pd
 import pyarrow as pa
 from fmu.sumo.explorer import Explorer, AggregatedTable
@@ -11,12 +17,37 @@ def fixture_explorer(token: str) -> Explorer:
     return Explorer("dev", token=token)
 
 
-# @pytest.fixture(name="case")
-# def case_fixture():
-#     """Init of case"""
-#     exp = Explorer("dev")
-#     case = exp.cases.filter(name="drogon_ahm-2023-02-22")[0]
-#     return case
+@pytest.fixture(name="table")
+def fixture_table(token: str, explorer: Explorer):
+    """Get one table for further testing."""
+    case = explorer.cases.filter(name="drogon_ahm-2023-02-22")[0]
+    return case.tables[0]
+    
+
+def test_table_dataframe(table):
+    """Test the dataframe property."""
+    with pytest.warns(DeprecationWarning, match=".dataframe is deprecated"):
+        df = table.dataframe
+    assert isinstance(df, pd.DataFrame)
+
+
+def test_table_to_pandas(table):
+    """Test the to_pandas property."""
+    df = table.to_pandas
+    assert isinstance(df, pd.DataFrame)
+
+
+def test_arrowtable(table):
+    """Test the arrowtable property."""
+    with pytest.warns(DeprecationWarning, match=".arrowtable is deprecated"):
+        arrow = table.arrowtable
+    assert isinstance(arrow, pa.Table)
+
+
+def test_table_to_arrow(table):
+    """Test the to_arrow() method"""
+    arrow = table.to_arrow()
+    assert isinstance(arrow, pa.Table)
 
 
 def test_aggregated_summary_arrow(explorer: Explorer):


### PR DESCRIPTION
Solve #267 

The `to_pandas` implementation is inconsistently implemented. In `Table`, it is implemented as a property. While similar looking `to_arrow` is a method. Also, the name indicates that this should be a function. `to_pandas` is also a function in other object classes, e.g. `Polygons.to_pandas()`.

🟩 This PR restructures the tests somewhat and adds tests for methods/functions that was not tested.
🟩 This PR changes `Table.to_pandas` from a property to a function. ⚠️ **Breaking change** ⚠️ 

Old pattern (discontinued with this PR):
```python
df = mytable.to_pandas
```

New pattern (introduced with this PR):
```python
df = mytable.to_pandas()
```

