### PR TITLE
Remove deprecated methods

### DIFF
--- a/src/fmu/sumo/explorer/objects/polygons.py
+++ b/src/fmu/sumo/explorer/objects/polygons.py
@@ -17,19 +17,6 @@ class Polygons(Child):
         """
         super().__init__(sumo, metadata)
 
-    def to_dataframe(self) -> pd.DataFrame:
-        """Get polygons object as a DataFrame
-
-        Returns:
-            DataFrame: A DataFrame object
-        """
-        warn(
-            ".to_dataframe() is deprecated, renamed to .to_pandas() ",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        return self.to_pandas()
 
     def to_pandas(self) -> pd.DataFrame:
         """Get polygons object as a DataFrame

--- a/src/fmu/sumo/explorer/objects/table.py
+++ b/src/fmu/sumo/explorer/objects/table.py
@@ -94,21 +94,6 @@ class Table(Child):
         return self._dataframe
 
 
-    @property
-    def arrowtable(self) -> pa.Table:
-        """Return object as an arrow Table
-
-        Returns:
-            pa.Table: _description_
-        """
-        warn(
-            ".arrowtable is deprecated, renamed to .to_arrow",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        return self.to_arrow()
-
     def to_arrow(self) -> pa.Table:
         """Return object as an arrow Table
 

--- a/src/fmu/sumo/explorer/objects/table.py
+++ b/src/fmu/sumo/explorer/objects/table.py
@@ -23,19 +23,6 @@ class Table(Child):
         self._arrowtable = None
         self._logger = logging.getLogger("__name__" + ".Table")
 
-    @property
-    def dataframe(self) -> pd.DataFrame:
-        """Return object as a pandas DataFrame
-
-        Returns:
-            DataFrame: A DataFrame object
-        """
-        warn(
-            ".dataframe is deprecated, renamed to .to_pandas",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.to_pandas()
 
 
     def to_pandas(self) -> pd.DataFrame:


### PR DESCRIPTION
This PR discontinues three deprecated methods:

- Polygons.to_dataframe()
- Table.dataframe()
- Table.arrowtable()