### PR TITLE
Discontinue deprecated methods

### DIFF
--- a/src/fmu/sumo/explorer/objects/polygons.py
+++ b/src/fmu/sumo/explorer/objects/polygons.py
@@ -17,20 +17,6 @@ class Polygons(Child):
         """
         super().__init__(sumo, metadata)
 
-    def to_dataframe(self) -> pd.DataFrame:
-        """Get polygons object as a DataFrame
-
-        Returns:
-            DataFrame: A DataFrame object
-        """
-        warn(
-            ".to_dataframe() is deprecated, renamed to .to_pandas() ",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        return self.to_pandas()
-
     def to_pandas(self) -> pd.DataFrame:
         """Get polygons object as a DataFrame
 

--- a/src/fmu/sumo/explorer/objects/table.py
+++ b/src/fmu/sumo/explorer/objects/table.py
@@ -23,20 +23,6 @@ class Table(Child):
         self._arrowtable = None
         self._logger = logging.getLogger("__name__" + ".Table")
 
-    @property
-    def dataframe(self) -> pd.DataFrame:
-        """Return object as a pandas DataFrame
-
-        Returns:
-            DataFrame: A DataFrame object
-        """
-        warn(
-            ".dataframe is deprecated, renamed to .to_pandas",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.to_pandas()
-
 
     def to_pandas(self) -> pd.DataFrame:
         """Return object as a pandas DataFrame

--- a/src/fmu/sumo/explorer/objects/table.py
+++ b/src/fmu/sumo/explorer/objects/table.py
@@ -93,21 +93,6 @@ class Table(Child):
         return self._dataframe
 
 
-    @property
-    def arrowtable(self) -> pa.Table:
-        """Return object as an arrow Table
-
-        Returns:
-            pa.Table: _description_
-        """
-        warn(
-            ".arrowtable is deprecated, renamed to .to_arrow",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        return self.to_arrow()
-
     def to_arrow(self) -> pa.Table:
         """Return object as an arrow Table
 

--- a/tests/test_objects_table.py
+++ b/tests/test_objects_table.py
@@ -30,13 +30,6 @@ def fixture_table(case):
     
 ### Table
 
-def test_table_dataframe(table):
-    """Test the dataframe property."""
-    with pytest.warns(DeprecationWarning, match=".dataframe is deprecated"):
-        df = table.dataframe
-    assert isinstance(df, pd.DataFrame)
-
-
 def test_table_to_pandas(table):
     """Test the to_pandas method."""
     df = table.to_pandas()

--- a/tests/test_objects_table.py
+++ b/tests/test_objects_table.py
@@ -35,14 +35,6 @@ def test_table_to_pandas(table):
     df = table.to_pandas()
     assert isinstance(df, pd.DataFrame)
 
-
-def test_arrowtable(table):
-    """Test the arrowtable property."""
-    with pytest.warns(DeprecationWarning, match=".arrowtable is deprecated"):
-        arrow = table.arrowtable
-    assert isinstance(arrow, pa.Table)
-
-
 def test_table_to_arrow(table):
     """Test the to_arrow() method"""
     arrow = table.to_arrow()
@@ -60,26 +52,6 @@ def test_aggregated_summary_arrow(case):
     column = table["FOPT"]
 
     assert isinstance(column.to_arrow(), pa.Table)
-    with pytest.raises(IndexError) as e_info:
-        table = table["banana"]
-        assert (
-            e_info.value.args[0] == "Column: 'banana' does not exist try again"
-        )
-
-
-def test_aggregated_summary_arrow_with_deprecated_function_name(case):
-    """Test usage of Aggregated class with default type with deprecated function name"""
-
-    table = AggregatedTable(case, "summary", "eclipse", "iter-0")
-
-    assert len(table.columns) == 972 + 2
-    column = table["FOPT"]
-
-    with pytest.warns(
-        DeprecationWarning,
-        match=".arrowtable is deprecated, renamed to .to_arrow()",
-    ):
-        assert isinstance(column.arrowtable, pa.Table)
     with pytest.raises(IndexError) as e_info:
         table = table["banana"]
         assert (


### PR DESCRIPTION
This PR discontinues three deprecated methods:

- `Polygons.to_dataframe()`
- `Table.dataframe()`
- `Table.arrowtable()`

All three methods have been flagged as deprecated for 6+ months.