### PR TITLE
add license classifier in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,10 @@ dynamic = ["version"]
 license = { file = "LICENSE" }
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [{ name = "Equinor" }]
-classifiers = ["Programming Language :: Python"]
+classifiers = [
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python",
+]
 dependencies = [
   "pandas>=1.1.3",
   "sumo-wrapper-python",


### PR DESCRIPTION
[Recommended practice to use the classifier when using standard licenses.](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license)