### PR TITLE
Add testing of SUMO access using different user identity on each test

### DIFF
--- a/.github/workflows/run_tests_access_drogon_manage_login.yaml
+++ b/.github/workflows/run_tests_access_drogon_manage_login.yaml
@@ -1,0 +1,49 @@
+name: Test access to Sumo with DROGON-MANAGE login
+
+on:
+  schedule:
+    - cron: "44 4 * * *"
+  workflow_dispatch:
+
+jobs:
+  build_pywheels:
+    name: PY ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+        os: [ubuntu-latest]
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Azure Login
+        uses: Azure/login@v1
+        with:
+          client-id: 0f8ab6eb-439b-4d3a-b765-301a6bc7f6cb
+          tenant-id: 3aa4a235-b6e2-48d5-9195-7fcf05b459b0
+          allow-no-subscriptions: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install fmu-sumo
+        run: >
+          python -m pip install --upgrade pip &&
+          python -m pip install .[test]
+      - name: Run tests
+        shell: bash
+        run: |
+          az --version
+          az account list
+          pip list | grep -i sumo
+          access_token=$(az account get-access-token --scope api://88d2b022-3539-4dda-9e66-853801334a86/.default --query accessToken --output tsv)
+          export ACCESS_TOKEN=$access_token
+
+          pytest -s --timeout=300 tests/test_access/tst_access_drogon_manage_login.py
+

--- a/.github/workflows/run_tests_access_drogon_read_login.yaml
+++ b/.github/workflows/run_tests_access_drogon_read_login.yaml
@@ -1,0 +1,49 @@
+name: Test access to Sumo with DROGON-READ login
+
+on:
+  schedule:
+    - cron: "24 4 * * *"
+  workflow_dispatch:
+
+jobs:
+  build_pywheels:
+    name: PY ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+        os: [ubuntu-latest]
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Azure Login
+        uses: Azure/login@v1
+        with:
+          client-id: 121279f7-331a-45fd-9a5f-62d9026694a7
+          tenant-id: 3aa4a235-b6e2-48d5-9195-7fcf05b459b0
+          allow-no-subscriptions: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install fmu-sumo
+        run: >
+          python -m pip install --upgrade pip &&
+          python -m pip install .[test]
+      - name: Run tests
+        shell: bash
+        run: |
+          az --version
+          az account list
+          pip list | grep -i sumo
+          access_token=$(az account get-access-token --scope api://88d2b022-3539-4dda-9e66-853801334a86/.default --query accessToken --output tsv)
+          export ACCESS_TOKEN=$access_token
+
+          pytest -s --timeout=300 tests/test_access/tst_access_drogon_read_login.py
+

--- a/.github/workflows/run_tests_access_drogon_write_login.yaml
+++ b/.github/workflows/run_tests_access_drogon_write_login.yaml
@@ -1,0 +1,49 @@
+name: Test access to Sumo with DROGON-WRITE login
+
+on:
+  schedule:
+    - cron: "34 4 * * *"
+  workflow_dispatch:
+
+jobs:
+  build_pywheels:
+    name: PY ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+        os: [ubuntu-latest]
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Azure Login
+        uses: Azure/login@v1
+        with:
+          client-id: 556cac03-e416-4ed6-86d7-d9d3f965d72e
+          tenant-id: 3aa4a235-b6e2-48d5-9195-7fcf05b459b0
+          allow-no-subscriptions: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install fmu-sumo
+        run: >
+          python -m pip install --upgrade pip &&
+          python -m pip install .[test]
+      - name: Run tests
+        shell: bash
+        run: |
+          az --version
+          az account list
+          pip list | grep -i sumo
+          access_token=$(az account get-access-token --scope api://88d2b022-3539-4dda-9e66-853801334a86/.default --query accessToken --output tsv)
+          export ACCESS_TOKEN=$access_token
+
+          pytest -s --timeout=300 tests/test_access/tst_access_drogon_write_login.py
+

--- a/.github/workflows/run_tests_access_no_access_login.yaml
+++ b/.github/workflows/run_tests_access_no_access_login.yaml
@@ -1,0 +1,49 @@
+name: Test access to Sumo with NO-ACCESS login
+
+on:
+  schedule:
+    - cron: "54 4 * * *"
+    workflow_dispatch:
+
+jobs:
+  build_pywheels:
+    name: PY ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+        os: [ubuntu-latest]
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Azure Login
+        uses: Azure/login@v1
+        with:
+          client-id: fea86a50-0f48-4cef-ba4d-1d789a00b701
+          tenant-id: 3aa4a235-b6e2-48d5-9195-7fcf05b459b0
+          allow-no-subscriptions: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install fmu-sumo
+        run: >
+          python -m pip install --upgrade pip &&
+          python -m pip install .[test]
+      - name: Run tests
+        shell: bash
+        run: |
+          az --version
+          az account list
+          pip list | grep -i sumo
+          access_token=$(az account get-access-token --scope api://88d2b022-3539-4dda-9e66-853801334a86/.default --query accessToken --output tsv)
+          export ACCESS_TOKEN=$access_token
+
+          pytest -s --timeout=300 tests/test_access/tst_access_no_access_login.py
+

--- a/tests/data/test_case_080/case2.json
+++ b/tests/data/test_case_080/case2.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.8.0/fmu_results.json",
+  "version": "0.8.0",
+  "source": "fmu",
+  "class": "case",
+  "access": {
+    "asset": {
+      "name": "Drogon"
+    }
+  },
+  "fmu": {
+    "model": {
+      "name": "ff",
+      "revision": "undefined"
+    },
+    "case": {
+      "name": "01_drogon_design_hubbabubba",
+      "uuid": "11111111-2222-3333-ba2a-afe535790707",
+      "user": {
+        "id": "some_user_01"
+      },
+      "description": []
+    }
+  },
+  "masterdata": {
+    "smda": {
+      "country": [
+        {
+          "identifier": "Norway",
+          "uuid": "ad214d85-8a1d-19da-e053-c918a4889309"
+        }
+      ],
+      "discovery": [
+        {
+          "short_identifier": "DROGON",
+          "uuid": "ad214d85-8a1d-19da-e053-c918a4889309"
+        }
+      ],
+      "field": [
+        {
+          "identifier": "DROGON",
+          "uuid": "00000000-0000-0000-0000-000000000000"
+        }
+      ],
+      "coordinate_system": {
+        "identifier": "ST_WGS84_UTM37N_P32637",
+        "uuid": "ad214d85-dac7-19da-e053-c918a4889309"
+      },
+      "stratigraphic_column": {
+        "identifier": "DROGON_HAS_NO_STRATCOLUMN",
+        "uuid": "00000000-0000-0000-0000-000000000000"
+      }
+    }
+  },
+  "tracklog": [ 
+    {
+        "datetime": "2024-02-06T07:01:40.564169+00:00",
+        "user": {
+          "id": "some_user"
+        },
+        "event": "created"
+      }
+  ]
+}

--- a/tests/test_access/README.md
+++ b/tests/test_access/README.md
@@ -1,0 +1,41 @@
+# Testing access to SUMO
+
+Tests in this folder shall be run inside Github Actions as specific 
+users with specific access. Each test file is tailored for a specific 
+user with either no-access, DROGON-READ, DROGON-WRITE or DROGON-MANAGE.
+Since you as a developer have different accesses, many tests will fail
+if you run them as yourself. 
+
+There are pytest skip decorators to avoid running these tests
+outside Github Actions. 
+In addition, the file names use the non-standard 'tst' over 'test' to avoid being picked 
+up by a call to pytest. 
+
+Print statements are used to ensure the Github Actions run provide 
+information that can be used for debugging. 
+
+Use allow-no-subscriptions flag to avoid having to give the App Registrations access to some resource inside the subscription itself. Example: 
+```
+      - name: Azure Login
+        uses: Azure/login@v1
+        with:
+          client-id: <relevant App Registration id here>
+          tenant-id: 3aa4a235-b6e2-48d5-9195-7fcf05b459b0
+          allow-no-subscriptions: true
+```
+
+If you want to run the tests on your laptop, using bash:
+export GITHUB_ACTIONS="true"
+
+In theory you could run locally as the App Registration / Service Principal but I 
+do not think the sumo-wrapper-python makes it possible:
+```
+az login --service-principal -u <app-id> -p <password-or-cert> --tenant <tenant> --allow-no-subscriptions
+```
+
+Relevant App Registrations:
+
+* sumo-test-runner-no-access No access
+* sumo-test-runner-drogon-read DROGON-READ
+* sumo-test-runner-drogon-write DROGON-WRITE
+* sumo-test-runner-drogon-manage DROGON-MANAGE

--- a/tests/test_access/tst_access_drogon_manage_login.py
+++ b/tests/test_access/tst_access_drogon_manage_login.py
@@ -1,0 +1,97 @@
+"""Test access to SUMO using a DROGON-MANAGE login.
+    Shall only run in Github Actions as a specific user with 
+    specific access rights. Running this test with your personal login
+    will fail."""
+import os
+import json
+import inspect
+import pytest
+from context import (
+    Explorer,
+)
+
+if os.getenv("GITHUB_ACTIONS") == "true":
+    RUNNING_OUTSIDE_GITHUB_ACTIONS = "False"
+    print(
+        "Found the GITHUB_ACTIONS env var, so I know I am running on Github now. Will run these tests."
+    )
+else:
+    RUNNING_OUTSIDE_GITHUB_ACTIONS = "True"
+    msg = "Skipping these tests since they can only run on Github Actions as a specific user"
+    print("NOT running on Github now.", msg)
+    pytest.skip(msg, allow_module_level=True)
+
+
+@pytest.fixture(name="explorer")
+def fixture_explorer(token: str) -> Explorer:
+    """Returns explorer"""
+    return Explorer("dev", token=token)
+
+
+def test_admin_access(explorer: Explorer):
+    """Test access to an admin endpoint"""
+    print("Running test:", inspect.currentframe().f_code.co_name)
+    with pytest.raises(Exception, match="403*"):
+        print("About to call an admin endpoint which should raise exception")
+        explorer._sumo.get(
+            f"/admin/make-shared-access-key?user=noreply%40equinor.com&roles=DROGON-READ&duration=111"
+        )
+        print("Execution should never reach this line")
+        assert True == False
+
+
+def test_get_userpermissions(explorer: Explorer):
+    """Test the userpermissions"""
+    print("Running test:", inspect.currentframe().f_code.co_name)
+    response = explorer._sumo.get(f"/userpermissions")
+    print("/Userpermissions response: ", response.text)
+    userperms = json.loads(response.text)
+    assert "Drogon" in userperms
+    assert "manage" in userperms.get("Drogon")
+    assert 1 == len(userperms.get("Drogon"))
+    assert 1 == len(userperms)
+
+
+def test_get_cases(explorer: Explorer):
+    """Test the get_cases method"""
+    print("Running test:", inspect.currentframe().f_code.co_name)
+    cases = explorer.cases
+    print("Number of cases: ", len(cases))
+    for case in cases:
+        assert case.field.lower() == "drogon"
+    assert len(cases) > 0
+
+
+def test_write(explorer: Explorer):
+    """Test a write method"""
+    print("Running test:", inspect.currentframe().f_code.co_name)
+    cases = explorer.cases
+    print("Number of cases: ", len(cases))
+    assert len(cases) > 0
+    case = cases[0]
+    print("case uuid:", case.metadata.get("fmu").get("case").get("uuid"))
+    print("About to write to a case")
+    response = explorer._sumo.post(f"/objects", json=case.metadata)
+    print(response.status_code)
+    print(response.text)
+    assert response.status_code == 200
+
+def test_read_restricted_classification_data(explorer: Explorer):
+    """Test if can read restriced data aka 'access:classification: restricted'"""
+    print("Running test:", inspect.currentframe().f_code.co_name)
+    cases = explorer.cases
+    print("Number of cases: ", len(cases))
+    assert len(cases) > 0
+
+    # A default Drogon iteration contains 2 restricted objects,
+    # so in normal situations there should be some restricted objects
+    response = explorer._sumo.get("/search?%24query=access.classification%3Arestricted")
+    assert response.status_code == 200
+    response_json = json.loads(response.text)
+    hits = response_json.get("hits").get("total").get("value")
+    print("Hits on restricted:", hits)
+    assert hits > 0 
+
+# TODO: aggregate bulk operation should fail 
+
+# TODO: FAST aggregate operation should succeed

--- a/tests/test_access/tst_access_drogon_read_login.py
+++ b/tests/test_access/tst_access_drogon_read_login.py
@@ -1,0 +1,98 @@
+"""Test access to SUMO using a DROGON-READ login.
+    Shall only run in Github Actions as a specific user with 
+    specific access rights. Running this test with your personal login
+    will fail."""
+import os
+import json
+import inspect
+import pytest
+from context import (
+    Explorer,
+)
+
+if os.getenv("GITHUB_ACTIONS") == "true":
+    RUNNING_OUTSIDE_GITHUB_ACTIONS = "False"
+    print(
+        "Found the GITHUB_ACTIONS env var, so I know I am running on Github now. Will run these tests."
+    )
+else:
+    RUNNING_OUTSIDE_GITHUB_ACTIONS = "True"
+    msg = "Skipping these tests since they can only run on Github Actions as a specific user"
+    print("NOT running on Github now.", msg)
+    pytest.skip(msg, allow_module_level=True)
+
+
+@pytest.fixture(name="explorer")
+def fixture_explorer(token: str) -> Explorer:
+    """Returns explorer"""
+    return Explorer("dev", token=token)
+
+
+def test_admin_access(explorer: Explorer):
+    """Test access to an admin endpoint"""
+    print("Running test:", inspect.currentframe().f_code.co_name)
+    with pytest.raises(Exception, match="403*"):
+        print("About to call an admin endpoint which should raise exception")
+        explorer._sumo.get(
+            f"/admin/make-shared-access-key?user=noreply%40equinor.com&roles=DROGON-READ&duration=111"
+        )
+        print("Execution should never reach this line")
+        assert True == False
+
+
+def test_get_userpermissions(explorer: Explorer):
+    """Test the userpermissions"""
+    print("Running test:", inspect.currentframe().f_code.co_name)
+    response = explorer._sumo.get(f"/userpermissions")
+    print("/Userpermissions response: ", response.text)
+    userperms = json.loads(response.text)
+    assert "Drogon" in userperms
+    assert "read" in userperms.get("Drogon")
+    assert 1 == len(userperms.get("Drogon"))
+    assert 1 == len(userperms)
+
+
+def test_get_cases(explorer: Explorer):
+    """Test the get_cases method"""
+    print("Running test:", inspect.currentframe().f_code.co_name)
+    cases = explorer.cases
+    print("Number of cases: ", len(cases))
+    for case in cases:
+        assert case.field.lower() == "drogon"
+    assert len(cases) > 0
+
+
+def test_write(explorer: Explorer):
+    """Test a write method"""
+    print("Running test:", inspect.currentframe().f_code.co_name)
+    cases = explorer.cases
+    print("Number of cases: ", len(cases))
+    assert len(cases) > 0
+    case = cases[0]
+    print("case uuid:", case.metadata.get("fmu").get("case").get("uuid"))
+    with pytest.raises(Exception, match="403*"):
+        print("About to write a case which should raise exception")
+        explorer._sumo.post(f"/objects", json=case.metadata)
+        print("Execution should never reach this line")
+        assert True == False
+
+def test_read_restricted_classification_data(explorer: Explorer):
+    """Test if can read restriced data aka 'access:classification: restricted'"""
+    print("Running test:", inspect.currentframe().f_code.co_name)
+    cases = explorer.cases
+    print("Number of cases: ", len(cases))
+    assert len(cases) > 0
+
+    # A default Drogon iteration contains 2 restricted objects,
+    # so in normal situations there should be some restricted objects,
+    # but never for this DROGON-READ user
+    response = explorer._sumo.get("/search?%24query=access.classification%3Arestricted")
+    assert response.status_code == 200
+    response_json = json.loads(response.text)
+    hits = response_json.get("hits").get("total").get("value")
+    print("Hits on restricted:", hits)
+    assert hits == 0
+
+# TODO: aggregate bulk operation should fail 
+
+# TODO: FAST aggregate operation should succeed

--- a/tests/test_access/tst_access_drogon_write_login.py
+++ b/tests/test_access/tst_access_drogon_write_login.py
@@ -1,0 +1,97 @@
+"""Test access to SUMO using a DROGON-WRITE login.
+    Shall only run in Github Actions as a specific user with 
+    specific access rights. Running this test with your personal login
+    will fail."""
+import os
+import json
+import inspect
+import pytest
+from context import (
+    Explorer,
+)
+
+if os.getenv("GITHUB_ACTIONS") == "true":
+    RUNNING_OUTSIDE_GITHUB_ACTIONS = "False"
+    print(
+        "Found the GITHUB_ACTIONS env var, so I know I am running on Github now. Will run these tests."
+    )
+else:
+    RUNNING_OUTSIDE_GITHUB_ACTIONS = "True"
+    msg = "Skipping these tests since they can only run on Github Actions as a specific user"
+    print("NOT running on Github now.", msg)
+    pytest.skip(msg, allow_module_level=True)
+
+
+@pytest.fixture(name="explorer")
+def fixture_explorer(token: str) -> Explorer:
+    """Returns explorer"""
+    return Explorer("dev", token=token)
+
+
+def test_admin_access(explorer: Explorer):
+    """Test access to an admin endpoint"""
+    print("Running test:", inspect.currentframe().f_code.co_name)
+    with pytest.raises(Exception, match="403*"):
+        print("About to call an admin endpoint which should raise exception")
+        explorer._sumo.get(
+            f"/admin/make-shared-access-key?user=noreply%40equinor.com&roles=DROGON-READ&duration=111"
+        )
+        print("Execution should never reach this line")
+        assert True == False
+
+
+def test_get_userpermissions(explorer: Explorer):
+    """Test the userpermissions"""
+    print("Running test:", inspect.currentframe().f_code.co_name)
+    response = explorer._sumo.get(f"/userpermissions")
+    print("/Userpermissions response: ", response.text)
+    userperms = json.loads(response.text)
+    assert "Drogon" in userperms
+    assert "write" in userperms.get("Drogon")
+    assert 1 == len(userperms.get("Drogon"))
+    assert 1 == len(userperms)
+
+
+def test_get_cases(explorer: Explorer):
+    """Test the get_cases method"""
+    print("Running test:", inspect.currentframe().f_code.co_name)
+    cases = explorer.cases
+    print("Number of cases: ", len(cases))
+    for case in cases:
+        assert case.field.lower() == "drogon"
+    assert len(cases) > 0
+
+
+def test_write(explorer: Explorer):
+    """Test a write method"""
+    print("Running test:", inspect.currentframe().f_code.co_name)
+    cases = explorer.cases
+    print("Number of cases: ", len(cases))
+    assert len(cases) > 0
+    case = cases[0]
+    print("case uuid:", case.metadata.get("fmu").get("case").get("uuid"))
+    print("About to write to a case")
+    response = explorer._sumo.post(f"/objects", json=case.metadata)
+    print(response.status_code)
+    print(response.text)
+    assert response.status_code == 200
+
+def test_read_restricted_classification_data(explorer: Explorer):
+    """Test if can read restriced data aka 'access:classification: restricted'"""
+    print("Running test:", inspect.currentframe().f_code.co_name)
+    cases = explorer.cases
+    print("Number of cases: ", len(cases))
+    assert len(cases) > 0
+
+    # A default Drogon iteration contains 2 restricted objects,
+    # so in normal situations there should be some restricted objects
+    response = explorer._sumo.get("/search?%24query=access.classification%3Arestricted")
+    assert response.status_code == 200
+    response_json = json.loads(response.text)
+    hits = response_json.get("hits").get("total").get("value")
+    print("Hits on restricted:", hits)
+    assert hits > 0 
+
+# TODO: aggregate bulk operation should fail 
+
+# TODO: FAST aggregate operation should succeed

--- a/tests/test_access/tst_access_no_access_login.py
+++ b/tests/test_access/tst_access_no_access_login.py
@@ -1,0 +1,104 @@
+"""Test access to SUMO using a no-access login.
+    Shall only run in Github Actions as a specific user with 
+    specific access rights. Running this test with your personal login
+    will fail."""
+import os
+import json
+import inspect
+import pytest
+from context import (
+    Explorer,
+)
+
+if os.getenv("GITHUB_ACTIONS") == "true":
+    RUNNING_OUTSIDE_GITHUB_ACTIONS = "False"
+    print(
+        "Found the GITHUB_ACTIONS env var, so I know I am running on Github now. Will run these tests."
+    )
+else:
+    RUNNING_OUTSIDE_GITHUB_ACTIONS = "True"
+    msg = "Skipping these tests since they can only run on Github Actions as a specific user"
+    print("NOT running on Github now.", msg)
+    pytest.skip(msg, allow_module_level=True)
+
+
+@pytest.fixture(name="explorer")
+def fixture_explorer(token: str) -> Explorer:
+    """Returns explorer"""
+    return Explorer("dev", token=token)
+
+
+def test_admin_access(explorer: Explorer):
+    """Test access to an admin endpoint"""
+    print("Running test:", inspect.currentframe().f_code.co_name)
+    with pytest.raises(Exception, match="403*"):
+        print("About to call an admin endpoint which should raise exception")
+        explorer._sumo.get(
+            f"/admin/make-shared-access-key?user=noreply%40equinor.com&roles=DROGON-READ&duration=111"
+        )
+        print("Execution should never reach this line")
+        assert True == False
+
+
+def test_get_userpermissions(explorer: Explorer):
+    """Test the userpermissions"""
+    print("Running test:", inspect.currentframe().f_code.co_name)
+    response = explorer._sumo.get(f"/userpermissions")
+    print("/Userpermissions response: ", response.text)
+    userperms = json.loads(response.text)
+    assert "Drogon" not in userperms
+    assert 0 == len(userperms)
+
+
+def test_get_cases(explorer: Explorer):
+    """Test the get_cases method"""
+    print("Running test:", inspect.currentframe().f_code.co_name)
+    cases = explorer.cases
+    print("Number of cases: ", len(cases))
+    for case in cases:
+        assert case.field.lower() == "drogon"
+    assert len(cases) == 0
+
+
+def test_write(explorer: Explorer):
+    """Test a write method"""
+    print("Running test:", inspect.currentframe().f_code.co_name)
+    cases = explorer.cases
+    print("Number of cases: ", len(cases))
+
+    with open("./tests/data/test_case_080/case2.json") as json_file:
+        metadata = json.load(json_file)
+        with pytest.raises(Exception, match="403*"):
+            print(
+                "About to call a write endpoint which should raise exception"
+            )
+            response = explorer._sumo.post("/objects", json=metadata)
+            print("Execution should never reach this line")
+            print("Unexpected status: ", response.status_code)
+            print("Unexpected response: ", response.text)
+            assert True == False
+
+
+def test_read_restricted_classification_data(explorer: Explorer):
+    """Test if can read restriced data aka 'access:classification: restricted'"""
+    print("Running test:", inspect.currentframe().f_code.co_name)
+    cases = explorer.cases
+    print("Number of cases: ", len(cases))
+    assert len(cases) > 0
+
+    # A default Drogon iteration contains 2 restricted objects,
+    # so in normal situations there should be some restricted objects
+    # but never for this user
+    response = explorer._sumo.get(
+        "/search?%24query=access.classification%3Arestricted"
+    )
+    assert response.status_code == 200
+    response_json = json.loads(response.text)
+    hits = response_json.get("hits").get("total").get("value")
+    print("Hits on restricted:", hits)
+    assert hits == 0
+
+
+# TODO: aggregate bulk operation should fail
+
+# TODO: FAST aggregate operation should succeed


### PR DESCRIPTION
## Issue
[https://github.com/equinor/fmu-sumo/issues/283](https://github.com/equinor/fmu-sumo/issues/283)

## Short description
_Short description of the approach taken to solve the issue_

## Pre-review checklist
- [ ] Read through all changes. No redundant `print()` statements, commented-out code, or other remnants from the development. 👀
- [ ] Make sure tests pass after every commit. ✅
- [ ] New/refactored code is following same conventions as the rest of the code base. 🧬
- [ ] New/refactored code is tested. ⚙
- [ ] Documentation has been updated 🧾

## Pre-merge checklist
- [ ] Commit history is consistent and clean. 👌
