### PR TITLE
Add support for content filtering

### DIFF
--- a/src/fmu/sumo/explorer/objects/_child_collection.py
+++ b/src/fmu/sumo/explorer/objects/_child_collection.py
@@ -107,6 +107,16 @@ class ChildCollection(DocumentCollection):
     async def vertical_domain_async(self) -> List[str]:
         """List of unqiue object vertical domain"""
         return await self._get_field_values_async("data.vertical_domain")
+   
+    @property
+    def contents(self) -> List[str]:
+        """List of unique contents"""
+        return self._get_field_values("data.content.keyword")
+
+    @property
+    async def contents_async(self) -> List[str]:
+        """List of unique contents"""
+        return self._get_field_values_async("data.content.keyword")
 
     def _init_query(self, doc_type: str, query: Dict = None) -> Dict:
         new_query = super()._init_query(doc_type, query)
@@ -133,6 +143,7 @@ class ChildCollection(DocumentCollection):
         uuid: Union[str, List[str], bool] = None,
         stratigraphic: Union[str, List[str], bool] = None,
         vertical_domain: Union[str, List[str], bool] = None,
+        content: Union[str, List[str], bool] = None,
         is_observation: bool = None,
         is_prediction: bool = None
     ):
@@ -148,7 +159,8 @@ class ChildCollection(DocumentCollection):
             "fmu.context.stage.keyword": stage,
             "data.spec.columns.keyword": column,
             "_id": uuid,
-            "data.vertical_domain.keyword": vertical_domain
+            "data.vertical_domain.keyword": vertical_domain,
+            "data.content.keyword": content
         }
 
         for prop, value in prop_map.items():

--- a/src/fmu/sumo/explorer/objects/cube_collection.py
+++ b/src/fmu/sumo/explorer/objects/cube_collection.py
@@ -134,6 +134,7 @@ class CubeCollection(ChildCollection):
         uuid: Union[str, List[str], bool] = None,
         is_observation: bool = None,
         is_prediction: bool = None,
+        content: Union[str, List[str], bool] = None,
     ) -> "CubeCollection":
         """Filter cubes
 
@@ -147,6 +148,7 @@ class CubeCollection(ChildCollection):
             uuid (Union[str, List[str], bool]): cube object uuid
             is_observation (bool): cube is_observation
             is_prediction (bool): cube is_prediction
+            content (Union[str, List[str], bool]): cube content
 
         Returns:
             CubeCollection: A filtered CubeCollection
@@ -161,6 +163,7 @@ class CubeCollection(ChildCollection):
             uuid=uuid,
             is_observation=is_observation,
             is_prediction=is_prediction,
+            content=content
         )
 
         return CubeCollection(self._sumo, self._case_uuid, query, self._pit)

--- a/src/fmu/sumo/explorer/objects/dictionary_collection.py
+++ b/src/fmu/sumo/explorer/objects/dictionary_collection.py
@@ -42,15 +42,17 @@ class DictionaryCollection(ChildCollection):
         aggregation: Union[str, List[str], bool] = None,
         stage: Union[str, List[str], bool] = None,
         uuid: Union[str, List[str], bool] = None,
+        content: Union[str, List[str], bool] = None,
     ) -> "DictionaryCollection":
         """Filter dictionaries
 
         Args:
-            name (Union[str, List[str], bool]): polygon name
-            tagname (Union[str, List[str], bool]): polygon tagname
+            name (Union[str, List[str], bool]): dictionary name
+            tagname (Union[str, List[str], bool]): dictionary tagname
             iteration (Union[int, List[int], bool]): iteration id
             realization Union[int, List[int], bool]: realization id
-            uuid (Union[str, List[str], bool]): polygons object uuid
+            uuid (Union[str, List[str], bool]): dictionary object uuid
+            content (Union[str, List[str], bool]): dictionary content
 
         Returns:
             DictionaryCollection: A filtered DictionaryCollection
@@ -63,6 +65,7 @@ class DictionaryCollection(ChildCollection):
             aggregation=aggregation,
             stage=stage,
             uuid=uuid,
+            content=content
         )
 
         return DictionaryCollection(

--- a/src/fmu/sumo/explorer/objects/polygons_collection.py
+++ b/src/fmu/sumo/explorer/objects/polygons_collection.py
@@ -40,6 +40,7 @@ class PolygonsCollection(ChildCollection):
         iteration: Union[str, List[str], bool] = None,
         realization: Union[int, List[int], bool] = None,
         uuid: Union[str, List[str], bool] = None,
+        content: Union[str, List[str], bool] = None,
     ) -> "PolygonsCollection":
         """Filter polygons
 
@@ -49,6 +50,7 @@ class PolygonsCollection(ChildCollection):
             iteration (Union[int, List[int], bool]): iteration id
             realization Union[int, List[int], bool]: realization id
             uuid (Union[str, List[str], bool]): polygons object uuid
+            content (Union[str, List[str], bool]): polygons content
 
         Returns:
             PolygonsCollection: A filtered PolygonsCollection
@@ -59,6 +61,7 @@ class PolygonsCollection(ChildCollection):
             iteration=iteration,
             realization=realization,
             uuid=uuid,
+            content=content
         )
 
         return PolygonsCollection(

--- a/src/fmu/sumo/explorer/objects/surface_collection.py
+++ b/src/fmu/sumo/explorer/objects/surface_collection.py
@@ -1,4 +1,5 @@
 """Module containing class for collection of surfaces"""
+
 from typing import Union, List, Dict, Tuple
 from io import BytesIO
 import xtgeo
@@ -173,8 +174,9 @@ class SurfaceCollection(ChildCollection):
         stage: Union[str, List[str], bool] = None,
         time: TimeFilter = None,
         uuid: Union[str, List[str], bool] = None,
+        content: Union[str, List[str], bool] = None,
         is_observation: bool = None,
-        is_prediction: bool = None
+        is_prediction: bool = None,
     ) -> "SurfaceCollection":
         """Filter surfaces
 
@@ -191,6 +193,7 @@ class SurfaceCollection(ChildCollection):
             uuid (Union[str, List[str], bool]): surface object uuid
             stratigraphic (Union[str, List[str], bool]): surface stratigraphic
             vertical_domain (Union[str, List[str], bool]): surface vertical_domain
+            content (Union[str, List[str], bool): = surface content
 
         Returns:
             SurfaceCollection: A filtered SurfaceCollection
@@ -241,8 +244,9 @@ class SurfaceCollection(ChildCollection):
             uuid=uuid,
             stratigraphic=stratigraphic,
             vertical_domain=vertical_domain,
+            content=content,
             is_observation=is_observation,
-            is_prediction=is_prediction
+            is_prediction=is_prediction,
         )
 
         return SurfaceCollection(self._sumo, self._case_uuid, query, self._pit)

--- a/src/fmu/sumo/explorer/objects/table_collection.py
+++ b/src/fmu/sumo/explorer/objects/table_collection.py
@@ -53,6 +53,7 @@ class TableCollection(ChildCollection):
         stage: Union[str, List[str], bool] = None,
         column: Union[str, List[str], bool] = None,
         uuid: Union[str, List[str], bool] = None,
+        content: Union[str, List[str], bool] = None,
     ) -> "TableCollection":
         """Filter tables
 
@@ -64,6 +65,7 @@ class TableCollection(ChildCollection):
             aggregation (Union[str, List[str], bool]): aggregation operation
             stage (Union[str, List[str], bool]): context/stage
             uuid (Union[str, List[str], bool]): table object uuid
+            content (Union[str, List[str], bool): table content
 
         Returns:
             TableCollection: A filtered TableCollection
@@ -78,5 +80,6 @@ class TableCollection(ChildCollection):
             stage=stage,
             column=column,
             uuid=uuid,
+            content=content
         )
         return TableCollection(self._sumo, self._case_uuid, query, self._pit)


### PR DESCRIPTION
## Issue
[_Link to the issue resolved by this PR._](https://github.com/orgs/equinor/projects/517/views/2?sliceBy%5Bvalue%5D=adnejacobsen&pane=issue&itemId=43076462)

## Short description
Add `content` parameter to `filter` methods and add a `contents` property for retrieving unique content values in a collection.

## Pre-review checklist
- [x] Read through all changes. No redundant `print()` statements, commented-out code, or other remnants from the development. 👀
- [x] Make sure tests pass after every commit. ✅
- [x] New/refactored code is following same conventions as the rest of the code base. 🧬
- [x] New/refactored code is tested. ⚙
- [x] Documentation has been updated 🧾

## Pre-merge checklist
- [x] Commit history is consistent and clean. 👌
