### PR TITLE
Case has filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ src/fmu/sumo/version.py
 testing.ipynb
 # files generated during testing
 *.csv
+
+# emacs backup files
+*~

--- a/docs/explorer.rst
+++ b/docs/explorer.rst
@@ -195,9 +195,9 @@ Finding cases with specific data types
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 There is also a filter that searches for cases where there are objects
 that match specific criteria. For example, if we define
-``4d-seismic`` as objects that have `data.content=seismic`,
-`data.time.t0.label=base` and `data.time.t1.label=monitor`, we can use
-the `has` filter to find cases that have ``4d-seismic`` data:
+``4d-seismic`` as objects that have ``data.content=seismic``,
+``data.time.t0.label=base`` and ``data.time.t1.label=monitor``, we can use
+the ``has`` filter to find cases that have ``4d-seismic`` data:
 
 .. code-block::
 
@@ -208,9 +208,9 @@ the `has` filter to find cases that have ``4d-seismic`` data:
    cases = exp.cases.filter(asset="Heidrun", has=Filters.seismic4d)
 
 In this case, we have a predefined filter for ``4d-seismic``, exposed
-thorugh `fmu.sumo.explorer.Filters`. There is no magic involved; any
+thorugh ``fmu.sumo.explorer.Filters``. There is no magic involved; any
 user can create their own filters, and either use them directly or ask
-for them to be added to `fmu.sumo.explorer.Filters`.
+for them to be added to ``fmu.sumo.explorer.Filters``.
 
 It is also possible to chain filters. The previous example could also
 be handled by

--- a/docs/explorer.rst
+++ b/docs/explorer.rst
@@ -195,7 +195,7 @@ Finding cases with specific data types
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 There is also a filter that searches for cases where there are objects
 that match specific criteria. For example, if we define
-``4d-seismic`` as objects that have ``data.content=seismic`,
+``4d-seismic`` as objects that have `data.content=seismic`,
 `data.time.t0.label=base` and `data.time.t1.label=monitor`, we can use
 the `has` filter to find cases that have ``4d-seismic`` data:
 

--- a/docs/explorer.rst
+++ b/docs/explorer.rst
@@ -191,6 +191,37 @@ You can also use a case `uuid` to get a `Case` object:
     my_case = sumo.get_case_by_uuid("1234567")
 
 
+Finding cases with specific data types
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+There is also a filter that searches for cases where there are objects
+that match specific criteria. For example, if we define
+``4d-seismic`` as objects that have ``data.content=seismic`,
+`data.time.t0.label=base` and `data.time.t1.label=monitor`, we can use
+the `has` filter to find cases that have ``4d-seismic`` data:
+
+.. code-block::
+
+   from fmu.sumo.explorer import Explorer, Filters
+
+   exp = Explorer(env="prod")
+
+   cases = exp.cases.filter(asset="Heidrun", has=Filters.seismic4d)
+
+In this case, we have a predefined filter for ``4d-seismic``, exposed
+thorugh `fmu.sumo.explorer.Filters`. There is no magic involved; any
+user can create their own filters, and either use them directly or ask
+for them to be added to `fmu.sumo.explorer.Filters`.
+
+It is also possible to chain filters. The previous example could also
+be handled by
+
+.. code-block::
+   cases = exp.cases.filter(asset="Heidrun",
+                            has={"term":{"data.content.keyword": "seismic"}})\
+     .filter(has={"term":{"data.time.t0.label.keyword":"base"}})\
+     .filter(has={"term":{"data.time.t1.label.keyword":"monitor"}})
+
+
 Browsing data in a case
 ^^^^^^^^^^^^^^^^^^^^^^^
 The `Case` object has properties for accessing different data types:

--- a/src/fmu/sumo/explorer/Filters.py
+++ b/src/fmu/sumo/explorer/Filters.py
@@ -1,0 +1,24 @@
+
+# Filter that matches 4d-seismic objects.
+
+seismic4d = {
+    "bool": {
+        "must": [
+            {
+                "term": {
+                    "data.content.keyword": "seismic"
+                }
+            },
+            {
+                "term": {
+                    "data.time.t0.label.keyword": "base"
+                }
+            },
+            {
+                "term": {
+                    "data.time.t1.label.keyword": "monitor"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## Issue
#325

## Short description
1. The `CaseCollection` constructor and the method `CaseCollection.filter()` have a new optional parameter called `has`. The `filter()` method generally returns a new `CaseCollection` instance; if `has` is specified, it is passed on to the constructor, which stores it in the member slot `_has`.
2. All searches on a `DocumentCollection` involve the `_next_batch()`/`_next_batch_async()` methods. These methods are overridden by `CaseCollection`.
3. `_next_batch()`/`_next_batch_async()` for `CaseCollection` checks if the member slot `_has` is set. If it is, we
   - Run a query to get all the values for `fmu.case.uuid` for the existing filters for the `CaseCollection` instance.
   - Create a new query that combines the value of `_has` with the set of values for `fmu.case.uuid`. Note: this new query applies to all object types, and not just `case` objects.
   - Retrieve all values for `fmu.case.uuid` for this new query.
   - Change the current filter for the `CaseCollection` instance to something like `{"ids": {"values": <uuids>}}`
   - Set the `_has`member attribute to `None`.
4. After checking/handling the `_has` attribute, `_next_batch()`/`_next_batch_async()` passes control to the parent class implementation.
## Pre-review checklist
- [ ] Read through all changes. No redundant `print()` statements, commented-out code, or other remnants from the development. 👀
- [✅] Make sure tests pass after every commit. ✅
- [✅] New/refactored code is following same conventions as the rest of the code base. 🧬
- [✅] New/refactored code is tested. ⚙
- [✅] Documentation has been updated 🧾

## Pre-merge checklist
- [ ] Commit history is consistent and clean. 👌
