### PR TITLE
Fix table.to_arrow() for data.format=parquet

### DIFF
--- a/src/fmu/sumo/explorer/objects/table.py
+++ b/src/fmu/sumo/explorer/objects/table.py
@@ -100,7 +100,10 @@ class Table(Child):
             pa.Table: _description_
         """
         if self._arrowtable is None:
-            if self["data"]["format"] == "arrow":
+            if self["data"]["format"] == "parquet":
+                worked = "parquet"
+                self._arrowtable = pq.read_table(self.blob)                
+            elif self["data"]["format"] == "arrow":
                 try:
                     worked = "feather"
                     self._arrowtable = pf.read_table(self.blob)


### PR DESCRIPTION
## Issue
_Link to the issue resolved by this PR._

## Short description
_Short description of the approach taken to solve the issue_

## Pre-review checklist
- [ ] Read through all changes. No redundant `print()` statements, commented-out code, or other remnants from the development. 👀
- [ ] Make sure tests pass after every commit. ✅
- [ ] New/refactored code is following same conventions as the rest of the code base. 🧬
- [ ] New/refactored code is tested. ⚙
- [ ] Documentation has been updated 🧾

## Pre-merge checklist
- [ ] Commit history is consistent and clean. 👌
