### PR TITLE
Added various metrics to SearchContext.

### DIFF
--- a/examples/metrics.ipynb
+++ b/examples/metrics.ipynb
@@ -1,0 +1,295 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a26f4146-4206-4f74-aba4-a9b165b00666",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fmu.sumo.explorer import Explorer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "9d04d0ea-b8ba-4891-ace1-4a5a8141e2c1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/RAYW/py-envs/explorer/lib/python3.9/site-packages/urllib3/__init__.py:35: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "exp=Explorer(env=\"preview\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0466932c-08c6-4a2b-991d-7ef752e37a87",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "case=exp.get_case_by_uuid(\"359e7c72-a4ca-43ee-9203-f09cd0f149a9\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "5981d890-3797-497a-8543-80c6a0b9af2c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tables=case.tables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "73f4b0aa-ec42-40af-bf47-eea30e6c265a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "summaries=tables.filter(tagname=\"summary\", realization=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "56160303-4881-4215-9daf-ce237c0b9bc6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'value': 49381964}"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "summaries.metrics.min(field=\"_sumo.blob_size\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "a5d63240-fb6e-477b-a1a7-41f99f2900b7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'value': 49691994}"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "summaries.metrics.max(field=\"_sumo.blob_size\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "2c218f8b-e210-40f8-be5a-5202efa1ef9d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'value': 49637090.18518519}"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "summaries.metrics.avg(field=\"_sumo.blob_size\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "393b2551-7d25-435a-89a9-5c3dbb3b3e51",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'count': 27,\n",
+       " 'min': 49381964,\n",
+       " 'max': 49691994,\n",
+       " 'avg': 49637090.18518519,\n",
+       " 'sum': 1340201435}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "summaries.metrics.stats(field=\"_sumo.blob_size\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "07d28bb7-eee9-41e4-a3e6-491aba7a3f4b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'count': 27,\n",
+       " 'min': 49381964,\n",
+       " 'max': 49691994,\n",
+       " 'avg': 49637090.18518519,\n",
+       " 'sum': 1340201435,\n",
+       " 'sum_of_squares': 66523854962491070,\n",
+       " 'variance': 5758040054.518518,\n",
+       " 'variance_population': 5758040054.518518,\n",
+       " 'variance_sampling': 5979503133.538462,\n",
+       " 'std_deviation': 75881.75047083797,\n",
+       " 'std_deviation_population': 75881.75047083797,\n",
+       " 'std_deviation_sampling': 77327.24703193863,\n",
+       " 'std_deviation_bounds': {'upper': 49788853.686126865,\n",
+       "  'lower': 49485326.68424351,\n",
+       "  'upper_population': 49788853.686126865,\n",
+       "  'lower_population': 49485326.68424351,\n",
+       "  'upper_sampling': 49791744.67924906,\n",
+       "  'lower_sampling': 49482435.69112131}}"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "summaries.metrics.extended_stats(field=\"_sumo.blob_size\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0355fa71-3605-46f0-bd22-872bbdfa3ac7",
+   "metadata": {},
+   "source": [
+    "summaries.metrics.percentiles(field=\"_sumo.blob_size\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "a2859bee-133e-4631-91d3-618c22d942eb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'values': {'1.0': 49393263.86,\n",
+       "  '5.0': 49444157,\n",
+       "  '25.0': 49649169.5,\n",
+       "  '50.0': 49655582,\n",
+       "  '75.0': 49675572.5,\n",
+       "  '95.0': 49685770.8,\n",
+       "  '99.0': 49690463.64}}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "summaries.metrics.percentiles(field=\"_sumo.blob_size\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "d6cb14c9-0a9a-4c91-bd86-7f783e3dcfcf",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'values': {'95.0': 49685770.8, '99.0': 49690463.64, '99.9': 49691840.964}}"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "summaries.metrics.percentiles(field=\"_sumo.blob_size\", percents=[95, 99, 99.9])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "91355328-db37-473f-aad8-e2c7d2fd7d10",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1.2481598509475589"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "summaries.metrics.sum(field=\"_sumo.blob_size\")[\"value\"]/(1024*1024*1024)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb3be689-6db2-483e-8195-2fcc3e1cdc69",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/metrics.ipynb
+++ b/examples/metrics.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "a26f4146-4206-4f74-aba4-a9b165b00666",
    "metadata": {},
    "outputs": [],
@@ -12,26 +12,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "9d04d0ea-b8ba-4891-ace1-4a5a8141e2c1",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/RAYW/py-envs/explorer/lib/python3.9/site-packages/urllib3/__init__.py:35: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020\n",
-      "  warnings.warn(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "exp=Explorer(env=\"preview\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "0466932c-08c6-4a2b-991d-7ef752e37a87",
    "metadata": {},
    "outputs": [],
@@ -41,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "5981d890-3797-497a-8543-80c6a0b9af2c",
    "metadata": {},
    "outputs": [],
@@ -51,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "73f4b0aa-ec42-40af-bf47-eea30e6c265a",
    "metadata": {},
    "outputs": [],
@@ -61,126 +52,50 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "56160303-4881-4215-9daf-ce237c0b9bc6",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'value': 49381964}"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "summaries.metrics.min(field=\"_sumo.blob_size\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "a5d63240-fb6e-477b-a1a7-41f99f2900b7",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'value': 49691994}"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "summaries.metrics.max(field=\"_sumo.blob_size\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "2c218f8b-e210-40f8-be5a-5202efa1ef9d",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'value': 49637090.18518519}"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "summaries.metrics.avg(field=\"_sumo.blob_size\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "393b2551-7d25-435a-89a9-5c3dbb3b3e51",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'count': 27,\n",
-       " 'min': 49381964,\n",
-       " 'max': 49691994,\n",
-       " 'avg': 49637090.18518519,\n",
-       " 'sum': 1340201435}"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "summaries.metrics.stats(field=\"_sumo.blob_size\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "07d28bb7-eee9-41e4-a3e6-491aba7a3f4b",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'count': 27,\n",
-       " 'min': 49381964,\n",
-       " 'max': 49691994,\n",
-       " 'avg': 49637090.18518519,\n",
-       " 'sum': 1340201435,\n",
-       " 'sum_of_squares': 66523854962491070,\n",
-       " 'variance': 5758040054.518518,\n",
-       " 'variance_population': 5758040054.518518,\n",
-       " 'variance_sampling': 5979503133.538462,\n",
-       " 'std_deviation': 75881.75047083797,\n",
-       " 'std_deviation_population': 75881.75047083797,\n",
-       " 'std_deviation_sampling': 77327.24703193863,\n",
-       " 'std_deviation_bounds': {'upper': 49788853.686126865,\n",
-       "  'lower': 49485326.68424351,\n",
-       "  'upper_population': 49788853.686126865,\n",
-       "  'lower_population': 49485326.68424351,\n",
-       "  'upper_sampling': 49791744.67924906,\n",
-       "  'lower_sampling': 49482435.69112131}}"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "summaries.metrics.extended_stats(field=\"_sumo.blob_size\")"
    ]
@@ -195,69 +110,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "a2859bee-133e-4631-91d3-618c22d942eb",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'values': {'1.0': 49393263.86,\n",
-       "  '5.0': 49444157,\n",
-       "  '25.0': 49649169.5,\n",
-       "  '50.0': 49655582,\n",
-       "  '75.0': 49675572.5,\n",
-       "  '95.0': 49685770.8,\n",
-       "  '99.0': 49690463.64}}"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "summaries.metrics.percentiles(field=\"_sumo.blob_size\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "d6cb14c9-0a9a-4c91-bd86-7f783e3dcfcf",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'values': {'95.0': 49685770.8, '99.0': 49690463.64, '99.9': 49691840.964}}"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "summaries.metrics.percentiles(field=\"_sumo.blob_size\", percents=[95, 99, 99.9])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "91355328-db37-473f-aad8-e2c7d2fd7d10",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1.2481598509475589"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "summaries.metrics.sum(field=\"_sumo.blob_size\")[\"value\"]/(1024*1024*1024)"
    ]

--- a/src/fmu/sumo/explorer/objects/__init__.py
+++ b/src/fmu/sumo/explorer/objects/__init__.py
@@ -1,6 +1,7 @@
 """Sumo cases and child objects"""
 
 from fmu.sumo.explorer.objects._search_context import SearchContext
+from fmu.sumo.explorer.objects._metrics import Metrics
 from fmu.sumo.explorer.objects.case import Case
 from fmu.sumo.explorer.objects.cases import Cases
 from fmu.sumo.explorer.objects.cube import Cube

--- a/src/fmu/sumo/explorer/objects/_metrics.py
+++ b/src/fmu/sumo/explorer/objects/_metrics.py
@@ -1,0 +1,47 @@
+class Metrics:
+    def __init__(self, search_context):
+        self._search_context = search_context
+        return
+
+    def _aggregate(self, op, **kwargs):
+        aggs = {"agg": {op: {k: v for k, v in kwargs.items() if v is not None}}}
+        qdoc = {"query": self._search_context._query,
+                "aggs": aggs,
+                "size": 0}
+        res = self._search_context._sumo.post("/search", json=qdoc).json()
+        return res["aggregations"]["agg"]
+                    
+    def min(self, field):
+        return self._aggregate("min", field=field)
+
+    def max(self, field):
+        return self._aggregate("max", field=field)
+
+    def avg(self, field):
+        return self._aggregate("avg", field=field)
+
+    def sum(self, field):
+        return self._aggregate("sum", field=field)
+
+    def value_count(self, field):
+        return self._aggregate("value_count", field=field)
+
+    def cardinality(self, field):
+        return self._aggregate("cardinality", field=field)
+
+    def stats(self, field):
+        return self._aggregate("stats", field=field)
+
+    def extended_stats(self, field):
+        return self._aggregate("extended_stats", field=field)
+
+    def percentiles(self, field, percents=None):
+        if percents is None:
+            return self._aggregate("percentiles", field=field)
+        else:
+            return self._aggregate("percentiles", field=field,
+                                   percents=percents)
+
+    
+
+        

--- a/src/fmu/sumo/explorer/objects/_metrics.py
+++ b/src/fmu/sumo/explorer/objects/_metrics.py
@@ -36,11 +36,8 @@ class Metrics:
         return self._aggregate("extended_stats", field=field)
 
     def percentiles(self, field, percents=None):
-        if percents is None:
-            return self._aggregate("percentiles", field=field)
-        else:
-            return self._aggregate("percentiles", field=field,
-                                   percents=percents)
+        return self._aggregate("percentiles", field=field,
+                               percents=percents)
 
     
 

--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -784,6 +784,11 @@ class SearchContext:
         return objects.Realizations(self)
 
     @property
+    def metrics(self):
+        """Metrics for current search context."""
+        return objects.Metrics(self)
+
+    @property
     def timestamps(self) -> List[str]:
         """List of unique timestamps in SearchContext"""
         ts = self.filter(complex=self._timestamp_query)._get_field_values(

--- a/tests/test_access/tst_access_drogon_affiliate_login.py
+++ b/tests/test_access/tst_access_drogon_affiliate_login.py
@@ -203,9 +203,9 @@ def test_read_restricted_classification_data(explorer: Explorer):
     print("Hits on restricted:", hits)
     assert hits >= 1
 
-@pytest.skipif(not (sys.platform == "linux" and
-                    sys.version_info[:2] == (3, 11)),
-               reason="Test only on single platform/version.")
+@pytest.mark.skipif(not (sys.platform == "linux" and
+                         sys.version_info[:2] == (3, 11)),
+                    reason="Test only on single platform/version.")
 def test_aggregate_bulk(explorer: Explorer):
     """Test a bulk aggregation method"""
     print("Running test:", inspect.currentframe().f_code.co_name)

--- a/tests/test_access/tst_access_drogon_affiliate_login.py
+++ b/tests/test_access/tst_access_drogon_affiliate_login.py
@@ -203,6 +203,9 @@ def test_read_restricted_classification_data(explorer: Explorer):
     print("Hits on restricted:", hits)
     assert hits >= 1
 
+@pytest.skipif(not (sys.platform == "linux" and
+                    sys.version_info[:2] == (3, 11)),
+               reason="Test only on single platform/version.")
 def test_aggregate_bulk(explorer: Explorer):
     """Test a bulk aggregation method"""
     print("Running test:", inspect.currentframe().f_code.co_name)

--- a/tests/test_access/tst_access_drogon_affiliate_login.py
+++ b/tests/test_access/tst_access_drogon_affiliate_login.py
@@ -3,6 +3,7 @@
     specific access rights. Running this test with your personal login
     will fail."""
 import os
+import sys
 import json
 import inspect
 import pytest

--- a/tests/test_access/tst_access_drogon_manage_login.py
+++ b/tests/test_access/tst_access_drogon_manage_login.py
@@ -4,6 +4,7 @@
     will fail."""
 
 import os
+import sys
 import json
 import inspect
 import pytest

--- a/tests/test_access/tst_access_drogon_manage_login.py
+++ b/tests/test_access/tst_access_drogon_manage_login.py
@@ -96,6 +96,9 @@ def test_read_restricted_classification_data(explorer: Explorer):
     assert hits > 0
 
 
+@pytest.skipif(not (sys.platform == "linux" and
+                    sys.version_info[:2] == (3, 11)),
+               reason="Test only on single platform/version.")
 def test_aggregations_bulk(explorer: Explorer):
     """Test a bulk aggregation method"""
     print("Running test:", inspect.currentframe().f_code.co_name)

--- a/tests/test_access/tst_access_drogon_manage_login.py
+++ b/tests/test_access/tst_access_drogon_manage_login.py
@@ -65,7 +65,7 @@ def test_get_cases(explorer: Explorer):
 def test_write(explorer: Explorer):
     """Test a write method"""
     print("Running test:", inspect.currentframe().f_code.co_name)
-    cases = explorer.cases
+    cases = explorer.cases.filter(status="scratch")
     print("Number of cases: ", len(cases))
     assert len(cases) > 0
     case = cases[0]
@@ -99,7 +99,7 @@ def test_read_restricted_classification_data(explorer: Explorer):
 def test_aggregations_bulk(explorer: Explorer):
     """Test a bulk aggregation method"""
     print("Running test:", inspect.currentframe().f_code.co_name)
-    cases = explorer.cases
+    cases = explorer.cases.filter(status="scratch")
     print("Number of cases: ", len(cases))
     assert len(cases) > 0
     case = None

--- a/tests/test_access/tst_access_drogon_manage_login.py
+++ b/tests/test_access/tst_access_drogon_manage_login.py
@@ -96,9 +96,9 @@ def test_read_restricted_classification_data(explorer: Explorer):
     assert hits > 0
 
 
-@pytest.skipif(not (sys.platform == "linux" and
-                    sys.version_info[:2] == (3, 11)),
-               reason="Test only on single platform/version.")
+@pytest.mark.skipif(not (sys.platform == "linux" and
+                         sys.version_info[:2] == (3, 11)),
+                    reason="Test only on single platform/version.")
 def test_aggregations_bulk(explorer: Explorer):
     """Test a bulk aggregation method"""
     print("Running test:", inspect.currentframe().f_code.co_name)

--- a/tests/test_access/tst_access_drogon_read_login.py
+++ b/tests/test_access/tst_access_drogon_read_login.py
@@ -3,6 +3,7 @@
     specific access rights. Running this test with your personal login
     will fail."""
 import os
+import sys
 import json
 import inspect
 import pytest

--- a/tests/test_access/tst_access_drogon_read_login.py
+++ b/tests/test_access/tst_access_drogon_read_login.py
@@ -150,9 +150,9 @@ def test_aggregations_fast(explorer: Explorer):
     print("Length of returned aggregate object:", len(response.text))
 
 
-@pytest.skipif(not (sys.platform == "linux" and
-                    sys.version_info[:2] == (3, 11)),
-               reason="Test only on single platform/version.")
+@pytest.mark.skipif(not (sys.platform == "linux" and
+                         sys.version_info[:2] == (3, 11)),
+                    reason="Test only on single platform/version.")
 def test_aggregate_bulk(explorer: Explorer):
     """Test a bulk aggregation method"""
     print("Running test:", inspect.currentframe().f_code.co_name)

--- a/tests/test_access/tst_access_drogon_read_login.py
+++ b/tests/test_access/tst_access_drogon_read_login.py
@@ -150,6 +150,9 @@ def test_aggregations_fast(explorer: Explorer):
     print("Length of returned aggregate object:", len(response.text))
 
 
+@pytest.skipif(not (sys.platform == "linux" and
+                    sys.version_info[:2] == (3, 11)),
+               reason="Test only on single platform/version.")
 def test_aggregate_bulk(explorer: Explorer):
     """Test a bulk aggregation method"""
     print("Running test:", inspect.currentframe().f_code.co_name)

--- a/tests/test_access/tst_access_drogon_write_login.py
+++ b/tests/test_access/tst_access_drogon_write_login.py
@@ -96,6 +96,9 @@ def test_read_restricted_classification_data(explorer: Explorer):
     assert hits > 0
 
 
+@pytest.skipif(not (sys.platform == "linux" and
+                    sys.version_info[:2] == (3, 11)),
+               reason="Test only on single platform/version.")
 def test_aggregate_bulk(explorer: Explorer):
     """Test a bulk aggregation method"""
     print("Running test:", inspect.currentframe().f_code.co_name)

--- a/tests/test_access/tst_access_drogon_write_login.py
+++ b/tests/test_access/tst_access_drogon_write_login.py
@@ -96,9 +96,9 @@ def test_read_restricted_classification_data(explorer: Explorer):
     assert hits > 0
 
 
-@pytest.skipif(not (sys.platform == "linux" and
-                    sys.version_info[:2] == (3, 11)),
-               reason="Test only on single platform/version.")
+@pytest.mark.skipif(not (sys.platform == "linux" and
+                         sys.version_info[:2] == (3, 11)),
+                    reason="Test only on single platform/version.")
 def test_aggregate_bulk(explorer: Explorer):
     """Test a bulk aggregation method"""
     print("Running test:", inspect.currentframe().f_code.co_name)

--- a/tests/test_access/tst_access_drogon_write_login.py
+++ b/tests/test_access/tst_access_drogon_write_login.py
@@ -4,6 +4,7 @@
     will fail."""
 
 import os
+import sys
 import json
 import inspect
 import pytest

--- a/tests/test_access/tst_access_drogon_write_login.py
+++ b/tests/test_access/tst_access_drogon_write_login.py
@@ -65,7 +65,7 @@ def test_get_cases(explorer: Explorer):
 def test_write(explorer: Explorer):
     """Test a write method"""
     print("Running test:", inspect.currentframe().f_code.co_name)
-    cases = explorer.cases
+    cases = explorer.cases.filter(status="scratch")
     print("Number of cases: ", len(cases))
     assert len(cases) > 0
     case = cases[0]
@@ -99,7 +99,7 @@ def test_read_restricted_classification_data(explorer: Explorer):
 def test_aggregate_bulk(explorer: Explorer):
     """Test a bulk aggregation method"""
     print("Running test:", inspect.currentframe().f_code.co_name)
-    cases = explorer.cases
+    cases = explorer.cases.filter(status="scratch")
     print("Number of cases: ", len(cases))
     assert len(cases) > 0
     case = None

--- a/tests/test_access/tst_access_no_access_login.py
+++ b/tests/test_access/tst_access_no_access_login.py
@@ -157,9 +157,9 @@ def test_get_message_log_truncate(explorer: Explorer):
         print("Unexpected response: ", response.text)
 
 
-@pytest.skipif(not (sys.platform == "linux" and
-                    sys.version_info[:2] == (3, 11)),
-               reason="Test only on single platform/version.")
+@pytest.mark.skipif(not (sys.platform == "linux" and
+                         sys.version_info[:2] == (3, 11)),
+                    reason="Test only on single platform/version.")
 def test_aggregate_bulk(explorer: Explorer):
     """Test a bulk aggregation method"""
     print("Running test:", inspect.currentframe().f_code.co_name)

--- a/tests/test_access/tst_access_no_access_login.py
+++ b/tests/test_access/tst_access_no_access_login.py
@@ -4,6 +4,7 @@
     will fail."""
 
 import os
+import sys
 import json
 import inspect
 import pytest

--- a/tests/test_access/tst_access_no_access_login.py
+++ b/tests/test_access/tst_access_no_access_login.py
@@ -157,6 +157,9 @@ def test_get_message_log_truncate(explorer: Explorer):
         print("Unexpected response: ", response.text)
 
 
+@pytest.skipif(not (sys.platform == "linux" and
+                    sys.version_info[:2] == (3, 11)),
+               reason="Test only on single platform/version.")
 def test_aggregate_bulk(explorer: Explorer):
     """Test a bulk aggregation method"""
     print("Running test:", inspect.currentframe().f_code.co_name)

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -196,14 +196,14 @@ def test_case_surfaces_type(test_case: Case):
 
 def test_case_surfaces_size(test_case: Case):
     """Test that Case.surfaces has the correct size"""
-    assert len(test_case.surfaces) == 219
+    assert len(test_case.surfaces) == 271
 
 
 def test_case_surfaces_filter(test_case: Case):
     """Test that Case.surfaces has the correct size"""
     # filter on iteration stage
     agg_surfs = test_case.surfaces.filter(stage="iteration")
-    assert len(agg_surfs) == 7
+    assert len(agg_surfs) == 59
 
     agg_surfs = test_case.surfaces.filter(aggregation=True)
     assert len(agg_surfs)


### PR DESCRIPTION
## Issue
N/A
## Short description
Adds various metrics aggregation to search contexts, specifically, "min", "max", "avg", "sum", "stats", "extended_stats",
"percentiles", "value_count" and "cardinality". These are accessed through the `metrics` member on class `SearchContext`. See examples in `examples/metrics.ipynb`.

## Pre-review checklist
- [x] Read through all changes. No redundant `print()` statements, commented-out code, or other remnants from the development. 👀
- [x] Make sure tests pass after every commit. ✅
- [x] New/refactored code is following same conventions as the rest of the code base. 🧬
- [x] New/refactored code is tested. ⚙
- [x] Documentation has been updated 🧾

## Pre-merge checklist
- [x] Commit history is consistent and clean. 👌
