### PR TITLE
fix: need await when calling async method.

### DIFF
--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -1036,7 +1036,7 @@ class SearchContext:
         return obj
 
     async def _get_object_by_class_and_uuid_async(self, cls, uuid):
-        obj = self.get_object_async(uuid)
+        obj = await self.get_object_async(uuid)
         if obj.metadata["class"] != cls:
             raise Exception(f"Document of type {cls} not found: {uuid}")
         return obj


### PR DESCRIPTION
## Issue
Bug reported by Webviz team on slack.
## Short description
Insert missing `await` in a call to async method.
## Pre-review checklist
- [ ] Read through all changes. No redundant `print()` statements, commented-out code, or other remnants from the development. 👀
- [ ] Make sure tests pass after every commit. ✅
- [ ] New/refactored code is following same conventions as the rest of the code base. 🧬
- [ ] New/refactored code is tested. ⚙
- [ ] Documentation has been updated 🧾

## Pre-merge checklist
- [ ] Commit history is consistent and clean. 👌
