### PR TITLE
fix: missing async for a length check and in get_iteration_by_uuid_async

### DIFF
--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -1405,7 +1405,8 @@ class SearchContext:
         return res
 
     async def aggregate_async(self, columns=None, operation=None):
-        if len(self.hidden) > 0:
+        length_hidden = await self.hidden.length_async()
+        if length_hidden > 0:
             return await self.hidden._aggregate_async(
                 columns=columns, operation=operation
             )

--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -1104,7 +1104,9 @@ class SearchContext:
         Returns: iteration object
         """
         res = (
-            await self._sumo.post("/search", json=self._iteration_query(uuid))
+            await self._sumo.post_async(
+                "/search", json=self._iteration_query(uuid)
+            )
         ).json()
         obj = res["hits"]["hits"][0]
         obj["_id"] = uuid


### PR DESCRIPTION
## Issue
#370

## Short description
Use async calls instead of sync calls.

## Pre-review checklist
- [ ] Read through all changes. No redundant `print()` statements, commented-out code, or other remnants from the development. 👀
- [ ] Make sure tests pass after every commit. ✅
- [ ] New/refactored code is following same conventions as the rest of the code base. 🧬
- [ ] New/refactored code is tested. ⚙
- [ ] Documentation has been updated 🧾

## Pre-merge checklist
- [ ] Commit history is consistent and clean. 👌
