### PR TITLE
feat: Make SearchContext.select() return self, so that the return value can…

### DIFF
--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -495,10 +495,14 @@ class SearchContext:
         the values are lists of strings. The string values are nested
         property names.
 
+        This method returns itself, so it is chainable, but the select
+        settings will not propagate into a new SearchContext
+        (specifically, it will not be passed into the result of .filter()).
+
         Args:
             sel (str | List(str) | Dict(str, List[str]): select specification
         Returns:
-            None
+            itself (SearchContext)
         """
 
         required = {"class"}
@@ -525,6 +529,7 @@ class SearchContext:
             self._select = slct
             pass
         self._cache.clear()
+        return self
 
     def get_object(self, uuid: str) -> Dict:
         """Get metadata object by uuid


### PR DESCRIPTION
… be used.

## Issue
N/A

## Short description
Make the method return `self`.

## Pre-review checklist
- [ ] Read through all changes. No redundant `print()` statements, commented-out code, or other remnants from the development. 👀
- [ ] Make sure tests pass after every commit. ✅
- [ ] New/refactored code is following same conventions as the rest of the code base. 🧬
- [ ] New/refactored code is tested. ⚙
- [ ] Documentation has been updated 🧾

## Pre-merge checklist
- [ ] Commit history is consistent and clean. 👌
