### PR TITLE
fix: correct selectors for cases, iterations and realizations

### DIFF
--- a/src/fmu/sumo/explorer/objects/cases.py
+++ b/src/fmu/sumo/explorer/objects/cases.py
@@ -5,9 +5,7 @@ from fmu.sumo.explorer.objects._search_context import SearchContext
 
 class Cases(SearchContext):
     def __init__(self, sc, uuids):
-        super().__init__(
-            sc._sumo, must=[{"ids": {"values": uuids}}]
-        )
+        super().__init__(sc._sumo, must=[{"ids": {"values": uuids}}])
         self._hits = uuids
         return
 

--- a/src/fmu/sumo/explorer/objects/cases.py
+++ b/src/fmu/sumo/explorer/objects/cases.py
@@ -6,7 +6,7 @@ from fmu.sumo.explorer.objects._search_context import SearchContext
 class Cases(SearchContext):
     def __init__(self, sc, uuids):
         super().__init__(
-            sc._sumo, must=[{"terms": {"fmu.case.uuid.keyword": uuids}}]
+            sc._sumo, must=[{"ids": {"values": uuids}}]
         )
         self._hits = uuids
         return

--- a/src/fmu/sumo/explorer/objects/iterations.py
+++ b/src/fmu/sumo/explorer/objects/iterations.py
@@ -8,7 +8,7 @@ from fmu.sumo.explorer.objects._search_context import SearchContext
 class Iterations(SearchContext):
     def __init__(self, sc, uuids):
         super().__init__(
-            sc._sumo, must=[{"terms": {"fmu.iteration.uuid.keyword": uuids}}]
+            sc._sumo, must=[{"ids": {"values": uuids}}]
         )
         self._hits = uuids
         return

--- a/src/fmu/sumo/explorer/objects/iterations.py
+++ b/src/fmu/sumo/explorer/objects/iterations.py
@@ -7,9 +7,7 @@ from fmu.sumo.explorer.objects._search_context import SearchContext
 
 class Iterations(SearchContext):
     def __init__(self, sc, uuids):
-        super().__init__(
-            sc._sumo, must=[{"ids": {"values": uuids}}]
-        )
+        super().__init__(sc._sumo, must=[{"ids": {"values": uuids}}])
         self._hits = uuids
         return
 

--- a/src/fmu/sumo/explorer/objects/realizations.py
+++ b/src/fmu/sumo/explorer/objects/realizations.py
@@ -8,7 +8,7 @@ from fmu.sumo.explorer.objects._search_context import SearchContext
 class Realizations(SearchContext):
     def __init__(self, sc, uuids):
         super().__init__(
-            sc._sumo, must=[{"terms": {"fmu.realization.uuid.keyword": uuids}}]
+            sc._sumo, must=[{"ids": {"values": uuids}}]
         )
         self._hits = uuids
         return

--- a/src/fmu/sumo/explorer/objects/realizations.py
+++ b/src/fmu/sumo/explorer/objects/realizations.py
@@ -7,9 +7,7 @@ from fmu.sumo.explorer.objects._search_context import SearchContext
 
 class Realizations(SearchContext):
     def __init__(self, sc, uuids):
-        super().__init__(
-            sc._sumo, must=[{"ids": {"values": uuids}}]
-        )
+        super().__init__(sc._sumo, must=[{"ids": {"values": uuids}}])
         self._hits = uuids
         return
 


### PR DESCRIPTION
The previous selector for the `SearchContext` part of `Cases` actually selected all children of the cases, and similarly for `Iterations` and `Realizations`. As an example, calling `len()` on an instance of `Cases` would actually return the total number of objects (including the `case` object) for all cases in the list, rather than the number of cases.