### PR TITLE
fix: improved grid property linkage

### DIFF
--- a/src/fmu/sumo/explorer/objects/_child.py
+++ b/src/fmu/sumo/explorer/objects/_child.py
@@ -12,6 +12,7 @@ _prop_desc = [
     ("dataname", "data.name", "Object name"),
     ("classname", "class.name", "Object class name"),
     ("casename", "fmu.case.name", "Object case name"),
+    ("caseuuid", "fmu.case.uuid", "Object case uuid"),
     ("content", "data.content", "Content"),
     ("tagname", "data.tagname", "Object tagname"),
     ("columns", "data.spec.columns", "Object table columns"),

--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -125,6 +125,7 @@ _filterspec = {
     "time": [_gen_filter_time, None],
     "name": [_gen_filter_name, None],
     "uuid": [_gen_filter_gen, "fmu.case.uuid.keyword"],
+    "relative_path": [_gen_filter_gen, "file.relative_path.keyword"],
     "tagname": [_gen_filter_gen, "data.tagname.keyword"],
     "dataformat": [_gen_filter_gen, "data.format.keyword"],
     "iteration": [_gen_filter_gen, "fmu.iteration.name.keyword"],

--- a/src/fmu/sumo/explorer/objects/cpgrid.py
+++ b/src/fmu/sumo/explorer/objects/cpgrid.py
@@ -59,26 +59,23 @@ class CPGrid(Child):
         Returns:
             GridProperties: a SearchContext that holds the linked CPGridProperty instances.
         """
-        sc = SearchContext(self._sumo)
+        sc = SearchContext(self._sumo).grid_properties.filter(
+            uuid=self.caseuuid,
+            iteration=self.iteration,
+            realization=self.realization,
+        )
         return sc.filter(
             complex={
                 "bool": {
-                    "must": [
+                    "minimum_should_match": 1,
+                    "should": [
                         {
                             "term": {
-                                "data.geometry.relative_path.keyword": self._metadata[
-                                    "file"
-                                ]["relative_path"]
+                                "data.geometry.relative_path.keyword": self.relative_path
                             }
                         },
-                        {
-                            "term": {
-                                "fmu.case.uuid.keyword": self._metadata["fmu"][
-                                    "case"
-                                ]["uuid"]
-                            }
-                        },
-                    ]
+                        {"term": {"data.tagname.keyword": self.name}},
+                    ],
                 }
-            }
+            },
         )

--- a/src/fmu/sumo/explorer/objects/cpgrid_property.py
+++ b/src/fmu/sumo/explorer/objects/cpgrid_property.py
@@ -67,21 +67,13 @@ class CPGridProperty(Child):
         should = [
             {"term": {"data.name.keyword": self.tagname}},
         ]
-        if (
+        dgrp = (
             self.metadata.get("data", {})
             .get("geometry", {})
             .get("relative_path", None)
-            is not None
-        ):
-            should.append(
-                {
-                    "term": {
-                        "file.relative_path.keyword": self._metadata["data"][
-                            "geometry"
-                        ]["relative_path"]
-                    }
-                }
-            )
+        )
+        if dgrp is not None:
+            should.append({"term": {"file.relative_path.keyword": dgrp}})
             pass
         sc = sc.filter(
             complex={

--- a/src/fmu/sumo/explorer/objects/cpgrid_property.py
+++ b/src/fmu/sumo/explorer/objects/cpgrid_property.py
@@ -59,25 +59,23 @@ class CPGridProperty(Child):
         Returns:
             Grid: a Grid object (an instance of class CPGrid).
         """
-        sc = SearchContext(self._sumo).filter(
+        sc = SearchContext(self._sumo).grids.filter(
+            uuid=self.caseuuid,
+            iteration=self.iteration,
+            realization=self.realization,
+        )
+        sc = sc.filter(
             complex={
                 "bool": {
-                    "must": [
+                    "minimum_should_match": 1,
+                    "should": [
                         {
                             "term": {
-                                "file.relative_path.keyword": self._metadata[
-                                    "data"
-                                ]["geometry"]["relative_path"]
+                                "file.relative_path.keyword": self._metadata["data"]["geometry"]["relative_path"]
                             }
                         },
-                        {
-                            "term": {
-                                "fmu.case.uuid.keyword": self._metadata["fmu"][
-                                    "case"
-                                ]["uuid"]
-                            }
-                        },
-                    ]
+                        {"term": {"data.name.keyword": self.tagname}},
+                    ],
                 }
             }
         )

--- a/src/fmu/sumo/explorer/objects/cpgrid_property.py
+++ b/src/fmu/sumo/explorer/objects/cpgrid_property.py
@@ -64,18 +64,30 @@ class CPGridProperty(Child):
             iteration=self.iteration,
             realization=self.realization,
         )
+        should = [
+            {"term": {"data.name.keyword": self.tagname}},
+        ]
+        if (
+            self.metadata.get("data", {})
+            .get("geometry", {})
+            .get("relative_path", None)
+            is not None
+        ):
+            should.append(
+                {
+                    "term": {
+                        "file.relative_path.keyword": self._metadata["data"][
+                            "geometry"
+                        ]["relative_path"]
+                    }
+                }
+            )
+            pass
         sc = sc.filter(
             complex={
                 "bool": {
                     "minimum_should_match": 1,
-                    "should": [
-                        {
-                            "term": {
-                                "file.relative_path.keyword": self._metadata["data"]["geometry"]["relative_path"]
-                            }
-                        },
-                        {"term": {"data.name.keyword": self.tagname}},
-                    ],
+                    "should": should,
                 }
             }
         )


### PR DESCRIPTION
`cpgrid` and `cpgrid_property` objects are supposed to be linked via the attributes `data.geometry.relative_path` (`cpgrid_property`)  and `file.relative_path` (`cpgrid`), with the additional requirement that the objects need to be of the correct classes and that case, iteration and realization should also match.

This requires that the sumo upload is correctly configured, which it mostly isn't. At some later time, it may be possible to update the objects already stored in Sumo and use just this linkage mechanism.

The alternative linkage uses `data.tagname` (`cpgrid_property`) and `data.name` (`cpgrid`), with the same addiotional requirements as above.