### PR TITLE
fix: Replace injected properties with explicitly defined properties.

### DIFF
--- a/src/fmu/sumo/explorer/objects/_child.py
+++ b/src/fmu/sumo/explorer/objects/_child.py
@@ -1,38 +1,11 @@
 """module containing class for child object"""
 
 from io import BytesIO
-from typing import Dict
+from typing import Dict, List
 
 from sumo.wrapper import SumoClient
 
 from fmu.sumo.explorer.objects._document import Document
-
-_prop_desc = [
-    ("name", "data.name", "Object name"),
-    ("dataname", "data.name", "Object name"),
-    ("classname", "class.name", "Object class name"),
-    ("casename", "fmu.case.name", "Object case name"),
-    ("caseuuid", "fmu.case.uuid", "Object case uuid"),
-    ("content", "data.content", "Content"),
-    ("tagname", "data.tagname", "Object tagname"),
-    ("columns", "data.spec.columns", "Object table columns"),
-    ("stratigraphic", "data.stratigraphic", "Object stratigraphic"),
-    ("vertical_domain", "data.vertical_domain", "Object vertical domain"),
-    ("context", "fmu.context.stage", "Object context"),
-    ("iteration", "fmu.iteration.name", "Object iteration"),
-    ("realization", "fmu.realization.id", "Object realization"),
-    (
-        "aggregation",
-        "fmu.aggregation.operation",
-        "Object aggregation operation",
-    ),
-    ("stage", "fmu.context.stage", "Object stage"),
-    ("format", "data.format", "Object file format"),
-    ("dataformat", "data.format", "Object file format"),
-    ("relative_path", "file.relative_path", "Object relative file path"),
-    ("bbox", "data.bbox", "Object boundary-box data"),
-    ("spec", "data.spec", "Object spec data"),
-]
 
 
 class Child(Document):
@@ -95,5 +68,102 @@ class Child(Document):
             + self.relative_path.split("/")[2:]
         )
 
+    @property
+    def spec(self) -> Dict:
+        """Object spec data"""
+        return self.get_property("data.spec")
 
-Child.map_properties(Child, _prop_desc)
+    @property
+    def bbox(self) -> Dict:
+        """Object boundary-box data"""
+        return self.get_property("data.bbox")
+
+    @property
+    def relative_path(self) -> str:
+        """Object relative file path"""
+        return self.get_property("file.relative_path")
+
+    @property
+    def dataformat(self) -> str:
+        """Object file format"""
+        return self.get_property("data.format")
+
+    @property
+    def format(self) -> str:
+        """Object file format"""
+        return self.get_property("data.format")
+
+    @property
+    def stage(self) -> str:
+        """Object stage"""
+        return self.get_property("fmu.context.stage")
+
+    @property
+    def aggregation(self) -> str:
+        """Object aggregation operation"""
+        return self.get_property("fmu.aggregation.operation")
+
+    @property
+    def realization(self) -> str:
+        """Object realization"""
+        return self.get_property("fmu.realization.id")
+
+    @property
+    def iteration(self) -> str:
+        """Object iteration"""
+        return self.get_property("fmu.iteration.name")
+
+    @property
+    def context(self) -> str:
+        """Object context"""
+        return self.get_property("fmu.context.stage")
+
+    @property
+    def vertical_domain(self) -> str:
+        """Object vertical domain"""
+        return self.get_property("data.vertical_domain")
+
+    @property
+    def stratigraphic(self) -> str:
+        """Object stratigraphic"""
+        return self.get_property("data.stratigraphic")
+
+    @property
+    def columns(self) -> List[str]:
+        """Object table columns"""
+        return self.get_property("data.spec.columns")
+
+    @property
+    def tagname(self) -> str:
+        """Object tagname"""
+        return self.get_property("data.tagname")
+
+    @property
+    def content(self) -> str:
+        """Content"""
+        return self.get_property("data.content")
+
+    @property
+    def caseuuid(self) -> str:
+        """Object case uuid"""
+        return self.get_property("fmu.case.uuid")
+
+    @property
+    def casename(self) -> str:
+        """Object case name"""
+        return self.get_property("fmu.case.name")
+
+    @property
+    def classname(self) -> str:
+        """Object class name"""
+        return self.get_property("class.name")
+
+    @property
+    def dataname(self) -> str:
+        """Object data name"""
+        return self.get_property("data.name")
+
+    @property
+    def name(self) -> str:
+        """Object data name"""
+        return self.get_property("data.name")

--- a/src/fmu/sumo/explorer/objects/_document.py
+++ b/src/fmu/sumo/explorer/objects/_document.py
@@ -1,7 +1,7 @@
 """Contains class for one document"""
 
 import re
-from typing import Dict, List
+from typing import Any, Dict, List, Union
 
 _path_split_rx = re.compile(r"\]\.|\.|\[")
 
@@ -9,11 +9,6 @@ _path_split_rx = re.compile(r"\]\.|\.|\[")
 def _splitpath(path):
     parts = _path_split_rx.split(path)
     return [int(x) if re.match(r"\d+", x) else x for x in parts]
-
-
-def _makeprop(attribute):
-    path = _splitpath(attribute)
-    return lambda self: self._get_property(path)
 
 
 class Document:
@@ -41,7 +36,7 @@ class Document:
         """
         return self._metadata
 
-    def _get_property(self, path: List[str]):
+    def _get_property(self, path: List[Union[str, int]]):
         curr = self._metadata
 
         for key in path:
@@ -52,10 +47,8 @@ class Document:
 
         return curr
 
+    def get_property(self, path: str) -> Any:
+        return self._get_property(_splitpath(path))
+
     def __getitem__(self, key: str):
         return self._metadata[key]
-
-    @staticmethod
-    def map_properties(cls, propmap):
-        for name, attribute, doc in propmap:
-            setattr(cls, name, property(_makeprop(attribute), None, None, doc))

--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -162,45 +162,6 @@ def _gen_filters(spec):
 filters = _gen_filters(_filterspec)
 
 
-_bucket_spec = {
-    "names": ["data.name.keyword", "List of unique object names."],
-    "tagnames": ["data.tagname.keyword", "List of unique object tagnames."],
-    "dataformats": [
-        "data.format.keyword",
-        "List of unique data.format values.",
-    ],
-    "aggregations": [
-        "fmu.aggregation.operation.keyword",
-        "List of unique object aggregation operations.",
-    ],
-    "stages": ["fmu.context.stage.keyword", "List of unique stages."],
-    # "stratigraphic": [
-    #     "data.stratigraphic",
-    #     "List of unique object stratigraphic.",
-    # ],
-    "vertical_domains": [
-        "data.vertical_domain",
-        "List of unique object vertical domains.",
-    ],
-    "contents": ["data.content.keyword", "List of unique contents."],
-    "columns": ["data.spec.columns.keyword", "List of unique column names."],
-    "statuses": ["_sumo.status.keyword", "List of unique case statuses."],
-    "users": ["fmu.case.user.id.keyword", "List of unique user names."],
-    "fieldidentifiers": [
-        "masterdata.smda.field.identifier.keyword",
-        "List of unique field names.",
-    ],
-    "stratcolumnidentifiers": [
-        "masterdata.smda.stratigraphic_column.identifier.keyword",
-        "List of unique stratigraphic column names.",
-    ],
-    "realizationids": [
-        "fmu.realization.id",
-        "List of unique realization ids.",
-    ],
-}
-
-
 def _build_bucket_query(query, field, size):
     return {
         "size": 0,
@@ -1547,6 +1508,146 @@ class SearchContext:
     def p90(self):
         return self.aggregate(operation="p90")
 
+    @property
+    def realizationids(self) -> List[int]:
+        """List of unique realization ids."""
+        return self.get_field_values("fmu.realization.id")
+
+    @property
+    async def realizationids_async(self) -> List[int]:
+        """List of unique realization ids."""
+        return await self.get_field_values_async("fmu.realization.id")
+
+    @property
+    def stratcolumnidentifiers(self) -> List[str]:
+        """List of unique stratigraphic column names."""
+        return self.get_field_values(
+            "masterdata.smda.stratigraphic_column.identifier.keyword"
+        )
+
+    @property
+    async def stratcolumnidentifiers_async(self) -> List[str]:
+        """List of unique stratigraphic column names."""
+        return await self.get_field_values_async(
+            "masterdata.smda.stratigraphic_column.identifier.keyword"
+        )
+
+    @property
+    def fieldidentifiers(self) -> List[str]:
+        """List of unique field names."""
+        return self.get_field_values(
+            "masterdata.smda.field.identifier.keyword"
+        )
+
+    @property
+    async def fieldidentifiers_async(self) -> List[str]:
+        """List of unique field names."""
+        return await self.get_field_values_async(
+            "masterdata.smda.field.identifier.keyword"
+        )
+
+    @property
+    def users(self) -> List[str]:
+        """List of unique user names."""
+        return self.get_field_values("fmu.case.user.id.keyword")
+
+    @property
+    async def users_async(self) -> List[str]:
+        """List of unique user names."""
+        return await self.get_field_values_async("fmu.case.user.id.keyword")
+
+    @property
+    def statuses(self) -> List[str]:
+        """List of unique case statuses."""
+        return self.get_field_values("_sumo.status.keyword")
+
+    @property
+    async def statuses_async(self) -> List[str]:
+        """List of unique case statuses."""
+        return await self.get_field_values_async("_sumo.status.keyword")
+
+    @property
+    def columns(self) -> List[str]:
+        """List of unique column names."""
+        return self.get_field_values("data.spec.columns.keyword")
+
+    @property
+    async def columns_async(self) -> List[str]:
+        """List of unique column names."""
+        return await self.get_field_values_async("data.spec.columns.keyword")
+
+    @property
+    def contents(self) -> List[str]:
+        """List of unique contents."""
+        return self.get_field_values("data.content.keyword")
+
+    @property
+    async def contents_async(self) -> List[str]:
+        """List of unique contents."""
+        return await self.get_field_values_async("data.content.keyword")
+
+    @property
+    def vertical_domains(self) -> List[str]:
+        """List of unique object vertical domains."""
+        return self.get_field_values("data.vertical_domain")
+
+    @property
+    async def vertical_domains_async(self) -> List[str]:
+        """List of unique object vertical domains."""
+        return await self.get_field_values_async("data.vertical_domain")
+
+    @property
+    def stages(self) -> List[str]:
+        """List of unique stages."""
+        return self.get_field_values("fmu.context.stage.keyword")
+
+    @property
+    async def stages_async(self) -> List[str]:
+        """List of unique stages."""
+        return await self.get_field_values_async("fmu.context.stage.keyword")
+
+    @property
+    def aggregations(self) -> List[str]:
+        """List of unique object aggregation operations."""
+        return self.get_field_values("fmu.aggregation.operation.keyword")
+
+    @property
+    async def aggregations_async(self) -> List[str]:
+        """List of unique object aggregation operations."""
+        return await self.get_field_values_async(
+            "fmu.aggregation.operation.keyword"
+        )
+
+    @property
+    def dataformats(self) -> List[str]:
+        """List of unique data.format values."""
+        return self.get_field_values("data.format.keyword")
+
+    @property
+    async def dataformats_async(self) -> List[str]:
+        """List of unique data.format values."""
+        return await self.get_field_values_async("data.format.keyword")
+
+    @property
+    def tagnames(self) -> List[str]:
+        """List of unique object tagnames."""
+        return self.get_field_values("data.tagname.keyword")
+
+    @property
+    async def tagnames_async(self) -> List[str]:
+        """List of unique object tagnames."""
+        return await self.get_field_values_async("data.tagname.keyword")
+
+    @property
+    def names(self) -> List[str]:
+        """List of unique object names."""
+        return self.get_field_values("data.name.keyword")
+
+    @property
+    async def names_async(self) -> List[str]:
+        """List of unique object names."""
+        return await self.get_field_values_async("data.name.keyword")
+
 
 def _gen_filter_doc(spec):
     fmap = {
@@ -1635,35 +1736,3 @@ Examples:
 
 
 SearchContext.filter.__doc__ = _gen_filter_doc(_filterspec)
-
-
-def _build_bucket_fn(property, docstring):
-    def fn(self):
-        return self.get_field_values(property)
-
-    return fn
-
-
-def _build_bucket_fn_async(property, docstring):
-    async def fn(self):
-        return await self.get_field_values_async(property)
-
-    return fn
-
-
-def _inject_bucket_fns(spec):
-    for name, defn in spec.items():
-        prop, docstring = defn
-        fn = _build_bucket_fn(prop, docstring)
-        setattr(SearchContext, name, property(fn, None, None, docstring))
-        afn = _build_bucket_fn_async(prop, docstring)
-        setattr(
-            SearchContext,
-            name + "_async",
-            property(afn, None, None, docstring),
-        )
-        pass
-    return
-
-
-_inject_bucket_fns(_bucket_spec)

--- a/src/fmu/sumo/explorer/objects/case.py
+++ b/src/fmu/sumo/explorer/objects/case.py
@@ -7,14 +7,6 @@ from sumo.wrapper import SumoClient
 from fmu.sumo.explorer.objects._document import Document
 from fmu.sumo.explorer.objects._search_context import SearchContext
 
-_prop_desc = [
-    ("name", "fmu.case.name", "Case name"),
-    ("status", "_sumo.status", "Case status"),
-    ("user", "fmu.case.user.id", "Name of user who uploaded case."),
-    ("asset", "access.asset.name", "Case asset"),
-    ("field", "masterdata.smda.field[0].identifier", "Case field"),
-]
-
 
 def _make_overview_query(id):
     return {
@@ -96,5 +88,27 @@ class Case(Document, SearchContext):
 
         return self._overview
 
+    @property
+    def field(self) -> str:
+        """Case field"""
+        return self.get_property("masterdata.smda.field[0].identifier")
 
-Case.map_properties(Case, _prop_desc)
+    @property
+    def asset(self) -> str:
+        """Case asset"""
+        return self.get_property("access.asset.name")
+
+    @property
+    def user(self) -> str:
+        """Name of user who uploaded case."""
+        return self.get_property("fmu.case.user.id")
+
+    @property
+    def status(self) -> str:
+        """Case status"""
+        return self.get_property("_sumo.status")
+
+    @property
+    def name(self) -> str:
+        """Case name"""
+        return self.get_property("fmu.case.name")

--- a/src/fmu/sumo/explorer/objects/iteration.py
+++ b/src/fmu/sumo/explorer/objects/iteration.py
@@ -7,15 +7,6 @@ from sumo.wrapper import SumoClient
 from fmu.sumo.explorer.objects._document import Document
 from fmu.sumo.explorer.objects._search_context import SearchContext
 
-_prop_desc = [
-    ("name", "fmu.iteration.name", "FMU iteration name"),
-    ("casename", "fmu.case.name", "FMU case name"),
-    ("caseuuid", "fmu.case.uuid", "FMU case uuid"),
-    ("user", "fmu.case.user.id", "Name of user who uploaded iteration."),
-    ("asset", "access.asset.name", "Case asset"),
-    ("field", "masterdata.smda.field[0].identifier", "Case field"),
-]
-
 
 class Iteration(Document, SearchContext):
     """Class for representing an iteration in Sumo."""
@@ -27,6 +18,34 @@ class Iteration(Document, SearchContext):
             sumo,
             must=[{"term": {"fmu.iteration.uuid.keyword": self.uuid}}],
         )
+        pass
 
+    @property
+    def field(self) -> str:
+        """Case field"""
+        return self.get_property("masterdata.smda.field[0].identifier")
 
-Iteration.map_properties(Iteration, _prop_desc)
+    @property
+    def asset(self) -> str:
+        """Case asset"""
+        return self.get_property("access.asset.name")
+
+    @property
+    def user(self) -> str:
+        """Name of user who uploaded iteration."""
+        return self.get_property("fmu.case.user.id")
+
+    @property
+    def caseuuid(self) -> str:
+        """FMU case uuid"""
+        return self.get_property("fmu.case.uuid")
+
+    @property
+    def casename(self) -> str:
+        """FMU case name"""
+        return self.get_property("fmu.case.name")
+
+    @property
+    def name(self) -> str:
+        """FMU iteration name"""
+        return self.get_property("fmu.iteration.name")

--- a/src/fmu/sumo/explorer/objects/realization.py
+++ b/src/fmu/sumo/explorer/objects/realization.py
@@ -7,16 +7,6 @@ from sumo.wrapper import SumoClient
 from fmu.sumo.explorer.objects._document import Document
 from fmu.sumo.explorer.objects._search_context import SearchContext
 
-_prop_desc = [
-    ("iterationname", "fmu.iteration.name", "FMU iteration name"),
-    ("iterationuuid", "fmu.iteration.uuid", "FMU iteration uuid"),
-    ("casename", "fmu.case.name", "FMU case name"),
-    ("caseuuid", "fmu.case.uuid", "FMU case uuid"),
-    ("user", "fmu.case.user.id", "Name of user who uploaded iteration."),
-    ("asset", "access.asset.name", "Case asset"),
-    ("field", "masterdata.smda.field[0].identifier", "Case field"),
-]
-
 
 class Realization(Document, SearchContext):
     """Class for representing a realization in Sumo."""
@@ -28,6 +18,39 @@ class Realization(Document, SearchContext):
             sumo,
             must=[{"term": {"fmu.realization.uuid.keyword": self.uuid}}],
         )
+        pass
 
+    @property
+    def field(self) -> str:
+        """Case field"""
+        return self.get_property("masterdata.smda.field[0].identifier")
 
-Realization.map_properties(Realization, _prop_desc)
+    @property
+    def asset(self) -> str:
+        """Case asset"""
+        return self.get_property("access.asset.name")
+
+    @property
+    def user(self) -> str:
+        """Name of user who uploaded iteration."""
+        return self.get_property("fmu.case.user.id")
+
+    @property
+    def caseuuid(self) -> str:
+        """FMU case uuid"""
+        return self.get_property("fmu.case.uuid")
+
+    @property
+    def casename(self) -> str:
+        """FMU case name"""
+        return self.get_property("fmu.case.name")
+
+    @property
+    def iterationuuid(self) -> str:
+        """FMU iteration uuid"""
+        return self.get_property("fmu.iteration.uuid")
+
+    @property
+    def iterationname(self) -> str:
+        """FMU iteration name"""
+        return self.get_property("fmu.iteration.name")


### PR DESCRIPTION
The idea of injecting properties into various class in `fmu.sumo.explorer` was _almost_ a good one, but it confused `pylint` and various IDE integrations.

This PR replaces the injected properties with explicitly coded properties.