### PR TITLE
chore: disable nightly test runs

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -3,8 +3,6 @@ name: Build and test fmu-sumo
 on:
   pull_request:
     branches: [main]
-  schedule:
-    - cron: "4 4 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The access tests were moved to another repo.
Don't see a reason to run these Explorer specific tests nightly, on PR should be enough?