### PR TITLE
fix: return realization and iteration objects if they exist

### DIFF
--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -303,6 +303,8 @@ class SearchContext:
             "table": objects.Table,
             "cpgrid": objects.CPGrid,
             "cpgrid_property": objects.CPGridProperty,
+            "iteration": objects.Iteration,
+            "realization": objects.Realization,
         }.get(cls)
         if constructor is None:
             warnings.warn(f"No constructor for class {cls}")
@@ -1100,6 +1102,7 @@ class SearchContext:
             "_source": {
                 "includes": [
                     "$schema",
+                    "class",
                     "source",
                     "version",
                     "access",
@@ -1118,12 +1121,21 @@ class SearchContext:
 
         Returns: iteration object
         """
-        res = self._sumo.post(
-            "/search", json=self._iteration_query(uuid)
-        ).json()
-        obj = res["hits"]["hits"][0]
-        obj["_id"] = uuid
-        return objects.Iteration(self._sumo, obj)
+        try:
+            obj = self.get_object(uuid)
+            assert isinstance(obj, objects.Iteration)
+            return obj
+        except Exception:
+            res = self._sumo.post(
+                "/search", json=self._iteration_query(uuid)
+            ).json()
+            hits = res["hits"]["hits"]
+            if len(hits) == 0:
+                raise Exception(f"Document not found: {uuid}")
+            obj = hits[0]
+            obj["_id"] = uuid
+            obj["_source"]["class"] = "iteration"
+            return self._to_sumo(obj)
 
     async def get_iteration_by_uuid_async(
         self, uuid: str
@@ -1135,14 +1147,23 @@ class SearchContext:
 
         Returns: iteration object
         """
-        res = (
-            await self._sumo.post_async(
-                "/search", json=self._iteration_query(uuid)
-            )
-        ).json()
-        obj = res["hits"]["hits"][0]
-        obj["_id"] = uuid
-        return objects.Iteration(self._sumo, obj)
+        try:
+            obj = await self.get_object_async(uuid)
+            assert isinstance(obj, objects.Iteration)
+            return obj
+        except Exception:
+            res = (
+                await self._sumo.post_async(
+                    "/search", json=self._iteration_query(uuid)
+                )
+            ).json()
+            hits = res["hits"]["hits"]
+            if len(hits) == 0:
+                raise Exception(f"Document not found: {uuid}")
+            obj = hits[0]
+            obj["_id"] = uuid
+            obj["_source"]["class"] = "iteration"
+            return self._to_sumo(obj)
 
     def _realization_query(self, uuid) -> Dict:
         return {
@@ -1153,6 +1174,7 @@ class SearchContext:
             "_source": {
                 "includes": [
                     "$schema",
+                    "class",
                     "source",
                     "version",
                     "access",
@@ -1172,12 +1194,21 @@ class SearchContext:
 
         Returns: realization object
         """
-        res = self._sumo.post(
-            "/search", json=self._realization_query(uuid)
-        ).json()
-        obj = res["hits"]["hits"][0]
-        obj["_id"] = uuid
-        return objects.Realization(self._sumo, obj)
+        try:
+            obj = self.get_object(uuid)
+            assert isinstance(obj, objects.Realization)
+            return obj
+        except Exception:
+            res = self._sumo.post(
+                "/search", json=self._realization_query(uuid)
+            ).json()
+            hits = res["hits"]["hits"]
+            if len(hits) == 0:
+                raise Exception(f"Document not found: {uuid}")
+            obj = hits[0]
+            obj["_id"] = uuid
+            obj["_source"]["class"] = "realization"
+            return self._to_sumo(obj)
 
     async def get_realization_by_uuid_async(
         self, uuid: str
@@ -1189,14 +1220,23 @@ class SearchContext:
 
         Returns: realization object
         """
-        res = (
-            await self._sumo.post_async(
-                "/search", json=self._realization_query(uuid)
-            )
-        ).json()
-        obj = res["hits"]["hits"][0]
-        obj["_id"] = uuid
-        return objects.Realization(self._sumo, obj)
+        try:
+            obj = await self.get_object_async(uuid)
+            assert isinstance(obj, objects.Realization)
+            return obj
+        except Exception:
+            res = (
+                await self._sumo.post_async(
+                    "/search", json=self._realization_query(uuid)
+                )
+            ).json()
+            hits = res["hits"]["hits"]
+            if len(hits) == 0:
+                raise Exception(f"Document not found: {uuid}")
+            obj = hits[0]
+            obj["_id"] = uuid
+            obj["_source"]["class"] = "realization"
+            return self._to_sumo(obj)
 
     def get_surface_by_uuid(self, uuid: str) -> objects.Surface:
         """Get surface object by uuid

--- a/src/fmu/sumo/explorer/objects/iteration.py
+++ b/src/fmu/sumo/explorer/objects/iteration.py
@@ -1,6 +1,6 @@
 """Module for (pseudo) iteration class."""
 
-from typing import Dict
+from typing import Dict, Optional
 
 from sumo.wrapper import SumoClient
 
@@ -11,7 +11,8 @@ from ._search_context import SearchContext
 class Iteration(Document, SearchContext):
     """Class for representing an iteration in Sumo."""
 
-    def __init__(self, sumo: SumoClient, metadata: Dict):
+    def __init__(self, sumo: SumoClient, metadata: Dict, blob: Optional[bytes] = None):
+        assert blob is None
         Document.__init__(self, metadata)
         SearchContext.__init__(
             self,

--- a/src/fmu/sumo/explorer/objects/iteration.py
+++ b/src/fmu/sumo/explorer/objects/iteration.py
@@ -11,7 +11,9 @@ from ._search_context import SearchContext
 class Iteration(Document, SearchContext):
     """Class for representing an iteration in Sumo."""
 
-    def __init__(self, sumo: SumoClient, metadata: Dict, blob: Optional[bytes] = None):
+    def __init__(
+        self, sumo: SumoClient, metadata: Dict, blob: Optional[bytes] = None
+    ):
         assert blob is None
         Document.__init__(self, metadata)
         SearchContext.__init__(
@@ -45,6 +47,16 @@ class Iteration(Document, SearchContext):
     def casename(self) -> str:
         """FMU case name"""
         return self.get_property("fmu.case.name")
+
+    @property
+    def iterationuuid(self) -> str:
+        """FMU iteration uuid"""
+        return self.get_property("fmu.iteration.uuid")
+
+    @property
+    def iterationname(self) -> str:
+        """FMU iteration name"""
+        return self.get_property("fmu.iteration.name")
 
     @property
     def name(self) -> str:

--- a/src/fmu/sumo/explorer/objects/realization.py
+++ b/src/fmu/sumo/explorer/objects/realization.py
@@ -1,6 +1,6 @@
 """Module for (pseudo) realization class."""
 
-from typing import Dict
+from typing import Dict, Optional
 
 from sumo.wrapper import SumoClient
 
@@ -11,7 +11,8 @@ from ._search_context import SearchContext
 class Realization(Document, SearchContext):
     """Class for representing a realization in Sumo."""
 
-    def __init__(self, sumo: SumoClient, metadata: Dict):
+    def __init__(self, sumo: SumoClient, metadata: Dict, blob: Optional[bytes] = None):
+        assert blob is None
         Document.__init__(self, metadata)
         SearchContext.__init__(
             self,

--- a/src/fmu/sumo/explorer/objects/realization.py
+++ b/src/fmu/sumo/explorer/objects/realization.py
@@ -11,7 +11,9 @@ from ._search_context import SearchContext
 class Realization(Document, SearchContext):
     """Class for representing a realization in Sumo."""
 
-    def __init__(self, sumo: SumoClient, metadata: Dict, blob: Optional[bytes] = None):
+    def __init__(
+        self, sumo: SumoClient, metadata: Dict, blob: Optional[bytes] = None
+    ):
         assert blob is None
         Document.__init__(self, metadata)
         SearchContext.__init__(
@@ -55,3 +57,23 @@ class Realization(Document, SearchContext):
     def iterationname(self) -> str:
         """FMU iteration name"""
         return self.get_property("fmu.iteration.name")
+
+    @property
+    def realizationuuid(self) -> str:
+        """FMU realization uuid"""
+        return self.get_property("fmu.realization.uuid")
+
+    @property
+    def realizationname(self) -> str:
+        """FMU realization name"""
+        return self.get_property("fmu.realization.name")
+
+    @property
+    def realizationid(self) -> int:
+        """FMU realization id"""
+        return self.get_property("fmu.realization.id")
+
+    @property
+    def name(self) -> str:
+        """FMU realization name"""
+        return self.get_property("fmu.realization.name")


### PR DESCRIPTION
When asked for "iteration" and realization objects, first try to get them from sumo. If the objects do not exist, synthesize them child objects.

Closes #388 