### PR TITLE
fix: Ensure that only appropriate objects are used as input to aggregation

### DIFF
--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -1553,7 +1553,7 @@ class SearchContext:
             if (
                 ("sum_other_doc_count" in v)
                 and (v["sum_other_doc_count"] > 0)
-                or v["buckets"][0]["doc_count"] != tot_hits
+                or ("buckets" in v and len(v["buckets"]) > 0 and v["buckets"][0]["doc_count"] != tot_hits)
             )
         ]
         if len(conflicts) > 0:
@@ -1612,10 +1612,11 @@ class SearchContext:
         return self._to_sumo(res)
 
     def aggregate(self, columns=None, operation=None) -> objects.Child:
-        if len(self.hidden) > 0:
-            return self.hidden._aggregate(columns=columns, operation=operation)
+        sc = self.filter(realization=True, column=columns)
+        if len(sc.hidden) > 0:
+            return sc.hidden._aggregate(columns=columns, operation=operation)
         else:
-            return self.visible._aggregate(
+            return sc.visible._aggregate(
                 columns=columns, operation=operation
             )
 
@@ -1657,13 +1658,14 @@ class SearchContext:
     async def aggregate_async(
         self, columns=None, operation=None
     ) -> objects.Child:
-        length_hidden = await self.hidden.length_async()
+        sc = self.filter(realization=True, column=columns)
+        length_hidden = await sc.hidden.length_async()
         if length_hidden > 0:
-            return await self.hidden._aggregate_async(
+            return await sc.hidden._aggregate_async(
                 columns=columns, operation=operation
             )
         else:
-            return await self.visible._aggregate_async(
+            return await sc.visible._aggregate_async(
                 columns=columns, operation=operation
             )
 

--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -1553,7 +1553,11 @@ class SearchContext:
             if (
                 ("sum_other_doc_count" in v)
                 and (v["sum_other_doc_count"] > 0)
-                or ("buckets" in v and len(v["buckets"]) > 0 and v["buckets"][0]["doc_count"] != tot_hits)
+                or (
+                    "buckets" in v
+                    and len(v["buckets"]) > 0
+                    and v["buckets"][0]["doc_count"] != tot_hits
+                )
             )
         ]
         if len(conflicts) > 0:
@@ -1616,9 +1620,7 @@ class SearchContext:
         if len(sc.hidden) > 0:
             return sc.hidden._aggregate(columns=columns, operation=operation)
         else:
-            return sc.visible._aggregate(
-                columns=columns, operation=operation
-            )
+            return sc.visible._aggregate(columns=columns, operation=operation)
 
     async def _verify_aggregation_operation_async(
         self, columns, operation


### PR DESCRIPTION
- Realization objects only.
- For table aggregation, only include realizations that contain the columns specified.

