### PR TITLE
fix: use python 3.12 when building docs

### DIFF
--- a/.github/workflows/check_formatting.yml
+++ b/.github/workflows/check_formatting.yml
@@ -14,18 +14,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      
+
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
-          cache: 'pip'
-      
+          python-version: "3.12"
+          cache: "pip"
+
       - name: Installing dependencies
         run: pip install ruff
-                
+
       - name: Run ruff lint
         run: ruff check .
 
       - name: Run ruff format
         run: ruff format . --check
-

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
     os: ubuntu-22.04
     tools:
-        python: "3.10"
+        python: "3.12"
 
 python:
     install:


### PR DESCRIPTION
readthedocs build fails due to using `Python 3.10` which is no longer supported.
Update to build using `Python 3.12`