### PR TITLE
fix: fix search context by making __str__ and __repr__ behave the same

### DIFF
--- a/src/fmu/sumo/explorer/objects/_child.py
+++ b/src/fmu/sumo/explorer/objects/_child.py
@@ -21,7 +21,7 @@ class Child(Document):
         self._sumo = sumo
         self._blob = blob
 
-    def __repr__(self):
+    def __str__(self):
         if self.stage == "case" and self.__class__.__name__ != "Case":
             return (
                 f"<{self.__class__.__name__}: {self.name} {self.uuid}(uuid) "
@@ -46,7 +46,10 @@ class Child(Document):
                     f"in asset {self.asset}>"
                 )
             else:
-                return super().__repr__()
+                return super().__str__()
+
+    def __repr__(self):
+        return self.__str__()
 
     @property
     def blob(self) -> BytesIO:

--- a/src/fmu/sumo/explorer/objects/_document.py
+++ b/src/fmu/sumo/explorer/objects/_document.py
@@ -1,6 +1,5 @@
 """Contains class for one document"""
 
-import json
 import re
 from typing import Any, Dict, List, Union
 

--- a/src/fmu/sumo/explorer/objects/_document.py
+++ b/src/fmu/sumo/explorer/objects/_document.py
@@ -20,13 +20,13 @@ class Document:
         self._metadata = metadata["_source"]
 
     def __str__(self):
-        return f"{json.dumps(self.metadata, indent=4)}"
-
-    def __repr__(self):
         return (
             f"<{self.__class__.__name__}: {self.name} {self.uuid}(uuid) "
             f"in asset {self.asset}>"
         )
+
+    def __repr__(self):
+        return self.__str__()
 
     @property
     def uuid(self):

--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import warnings
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union

--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -299,14 +299,6 @@ class SearchContext:
         return
 
     def __str__(self):
-        length = len(self)
-        if length == 0:
-            return "None"
-        else:
-            preview = [self[i].metadata for i in range(min(5, length))]
-            return f"Data Preview:\n{json.dumps(preview, indent=4)}"
-
-    def __repr__(self):
         cls = self.__class__.__name__
         length = len(self)
         if length == 0:
@@ -316,6 +308,9 @@ class SearchContext:
                 return f"<{cls}: {length} objects of type {self.classes[0]}>"
             else:
                 return f"<{cls}: {length} objects of types {self.classes}>"
+
+    def __repr__(self):
+        return self.__str__()
 
     @property
     def _query(self):

--- a/src/fmu/sumo/explorer/objects/ensemble.py
+++ b/src/fmu/sumo/explorer/objects/ensemble.py
@@ -23,12 +23,15 @@ class Ensemble(Document, SearchContext):
         )
         pass
 
-    def __repr__(self):
+    def __str__(self):
         return (
             f"<{self.__class__.__name__}: {self.name} {self.uuid}(uuid) "
             f"in case {self.casename} "
             f"in asset {self.asset}>"
         )
+
+    def __repr__(self):
+        return self.__str__()
 
     @property
     def field(self) -> str:

--- a/src/fmu/sumo/explorer/objects/iteration.py
+++ b/src/fmu/sumo/explorer/objects/iteration.py
@@ -23,12 +23,15 @@ class Iteration(Document, SearchContext):
         )
         pass
 
-    def __repr__(self):
+    def __str__(self):
         return (
             f"<{self.__class__.__name__}: {self.name} {self.uuid}(uuid) "
             f"in case {self.casename} "
             f"in asset {self.asset}>"
         )
+
+    def __repr__(self):
+        return self.__str__()
 
     @property
     def field(self) -> str:

--- a/src/fmu/sumo/explorer/objects/realization.py
+++ b/src/fmu/sumo/explorer/objects/realization.py
@@ -23,13 +23,16 @@ class Realization(Document, SearchContext):
         )
         pass
 
-    def __repr__(self):
+    def __str__(self):
         return (
             f"<{self.__class__.__name__}: {self.realizationid} {self.uuid}(uuid) "
             f"in iteration {self.iterationname} "
             f"in case {self.casename} "
             f"in asset {self.asset}>"
         )
+
+    def __repr__(self):
+        return self.__str__()
 
     @property
     def field(self) -> str:


### PR DESCRIPTION
Close https://github.com/equinor/fmu-sumo/issues/433

- For search context __str__ and  __repr__ will behave the same
- For some classes, the __str__ is not properly setup. For example in the `Ensemble` class, the __str__ is not specified so it is inherited from the parent class. But it is lacking ensemble name. 
