### PR TITLE
feat: reference realizations

### DIFF
--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -1007,6 +1007,22 @@ class SearchContext:
         return objects.Realizations(self, uuids)
 
     @property
+    def reference_realizations(self):
+        """Reference realizations from current selection."""
+        return self.filter(
+            cls="realization",
+            complex={"term": {"fmu.realization.is_reference": True}},
+        )
+
+    @property
+    async def reference_realizations_async(self):
+        """Reference realizations from current selection."""
+        return self.filter(
+            cls="realization",
+            complex={"term": {"fmu.realization.is_reference": True}},
+        )
+
+    @property
     def template_paths(self) -> List[str]:
         return {obj.template_path for obj in self}
 

--- a/src/fmu/sumo/explorer/objects/ensemble.py
+++ b/src/fmu/sumo/explorer/objects/ensemble.py
@@ -77,3 +77,23 @@ class Ensemble(Document, SearchContext):
     def uuid(self) -> str:
         """FMU ensemble uuid"""
         return self.get_property("fmu.ensemble.uuid")
+
+    @property
+    def reference_realizations(self):
+        """Reference realizations in ensemble. If none, return
+        realizations 0 and 1, if they exist."""
+        sc = super().reference_realizations
+        if len(sc) > 0:
+            return sc
+        else:
+            return self.filter(realization=[0, 1]).realizations
+
+    @property
+    async def reference_realizations_async(self):
+        """Reference realizations in ensemble. If none, return
+        realizations 0 and 1, if they exist."""
+        sc = await super().reference_realizations_async
+        if await sc.length_async() > 0:
+            return sc
+        else:
+            return self.filter(realization=[0, 1]).realizations

--- a/src/fmu/sumo/explorer/objects/realization.py
+++ b/src/fmu/sumo/explorer/objects/realization.py
@@ -83,3 +83,8 @@ class Realization(Document, SearchContext):
     def realizationid(self) -> int:
         """FMU realization id"""
         return self.get_property("fmu.realization.id")
+
+    @property
+    def is_reference(self) -> bool:
+        """Check if reference realization."""
+        return self.get_property("fmu.realizations.is_reference") is True

--- a/src/fmu/sumo/explorer/objects/realization.py
+++ b/src/fmu/sumo/explorer/objects/realization.py
@@ -87,4 +87,4 @@ class Realization(Document, SearchContext):
     @property
     def is_reference(self) -> bool:
         """Check if reference realization."""
-        return self.get_property("fmu.realizations.is_reference") is True
+        return self.get_property("fmu.realization.is_reference") is True

--- a/src/fmu/sumo/explorer/objects/realizations.py
+++ b/src/fmu/sumo/explorer/objects/realizations.py
@@ -1,8 +1,9 @@
 """Module for searchcontext for collection of realizations."""
 
-from typing import Dict
+from typing import Dict, List
 
 from ._search_context import SearchContext
+from .realization import Realization
 
 
 class Realizations(SearchContext):
@@ -17,7 +18,7 @@ class Realizations(SearchContext):
     async def _maybe_prefetch_async(self, index):
         return
 
-    def get_object(self, uuid: str) -> Dict:
+    def get_object(self, uuid: str) -> Realization:
         """Get metadata object by uuid
 
         Args:
@@ -35,7 +36,7 @@ class Realizations(SearchContext):
 
         return obj
 
-    async def get_object_async(self, uuid: str) -> Dict:
+    async def get_object_async(self, uuid: str) -> Realization:
         """Get metadata object by uuid
 
         Args:
@@ -57,3 +58,22 @@ class Realizations(SearchContext):
         sc = super().filter(**kwargs)
         uuids = sc.get_field_values("fmu.realization.uuid.keyword")
         return Realizations(self, uuids)
+
+    @property
+    def classes(self) -> List[str]:
+        return ["realization"]
+
+    @property
+    async def classes_async(self) -> List[str]:
+        return ["realization"]
+
+    @property
+    def realizationids(self) -> List[int]:
+        return [self.get_object(uuid).realizationid for uuid in self._hits]
+
+    @property
+    async def realizationids_async(self) -> List[int]:
+        return [
+            (await self.get_object_async(uuid)).realizationid
+            for uuid in self._hits
+        ]


### PR DESCRIPTION
Add functionality to extract reference realizations from an ensemble. This is either

- The realizations that have the property `fmu.realization.is_reference` set to `True`

or

- Realizations with `fmu.realization.id` set to `0` or `1`.