### PR TITLE
feat: raise exception if filter on realization for table and parameter aggregation

### DIFF
--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -1503,9 +1503,13 @@ class SearchContext:
         ]
         classname = sres["aggregations"]["class"]["buckets"][0]["key"]
 
-        sc=SearchContext(sumo=self._sumo, must=[{"exists": {"field":  "fmu.realization.id"}}]).filter(entity=entityuuid, ensemble=ensemblename)
+        sc = SearchContext(
+            sumo=self._sumo, must=[{"exists": {"field": "fmu.realization.id"}}]
+        ).filter(entity=entityuuid, ensemble=ensemblename)
         if len(sc) != tot_hits and classname != "surface":
-            raise Exception("Filtering on realization is not allowed for table and parameter aggregation.")
+            raise Exception(
+                "Filtering on realization is not allowed for table and parameter aggregation."
+            )
 
         return caseuuid, classname, entityuuid, ensemblename
 

--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -1503,57 +1503,7 @@ class SearchContext:
         ]
         classname = sres["aggregations"]["class"]["buckets"][0]["key"]
 
-        sc = SearchContext(
-            sumo=self._sumo, must=[{"exists": {"field": "fmu.realization.id"}}]
-        ).filter(entity=entityuuid, ensemble=ensemblename)
-        if len(sc) != tot_hits and classname != "surface":
-            raise Exception(
-                "Filtering on realization is not allowed for table and parameter aggregation."
-            )
-
-        return caseuuid, classname, entityuuid, ensemblename
-
-    async def __verify_aggregation_operation_async(
-        self, sres
-    ) -> Tuple[str, str, str, str]:
-        tot_hits = sres["hits"]["total"]["value"]
-        if tot_hits == 0:
-            raise Exception("No matching realizations found.")
-        conflicts = [
-            k
-            for (k, v) in sres["aggregations"].items()
-            if (
-                ("sum_other_doc_count" in v)
-                and (v["sum_other_doc_count"] > 0)
-                or (
-                    "buckets" in v
-                    and len(v["buckets"]) > 0
-                    and v["buckets"][0]["doc_count"] != tot_hits
-                )
-            )
-        ]
-        if len(conflicts) > 0:
-            raise Exception(f"Conflicting values for {conflicts}")
-        entityuuid = sres["aggregations"]["fmu.entity.uuid"]["buckets"][0][
-            "key"
-        ]
-        caseuuid = sres["aggregations"]["fmu.case.uuid"]["buckets"][0]["key"]
-        ensemblename = sres["aggregations"]["fmu.ensemble.name"]["buckets"][0][
-            "key"
-        ]
-        classname = sres["aggregations"]["class"]["buckets"][0]["key"]
-
-        sc = SearchContext(
-            sumo=self._sumo, must=[{"exists": {"field": "fmu.realization.id"}}]
-        ).filter(entity=entityuuid, ensemble=ensemblename)
-
-        tot_reals = await sc.length_async()
-        if tot_reals != tot_hits and classname != "surface":
-            raise Exception(
-                "Filtering on realization is not allowed for table and parameter aggregation."
-            )
-
-        return caseuuid, classname, entityuuid, ensemblename
+        return caseuuid, classname, entityuuid, ensemblename, tot_hits
 
     def _verify_aggregation_operation(
         self, columns
@@ -1564,7 +1514,21 @@ class SearchContext:
         sc = self if columns is None else self.filter(column=columns)
         query = sc.__prepare_verify_aggregation_query()
         sres = sc._sumo.post("/search", json=query).json()
-        return sc.__verify_aggregation_operation(sres)
+        caseuuid, classname, entityuuid, ensemblename, tot_hits = (
+            sc.__verify_aggregation_operation(sres)
+        )
+
+        if classname != "surface":
+            sc = SearchContext(
+                sumo=self._sumo,
+                must=[{"exists": {"field": "fmu.realization.id"}}],
+            ).filter(entity=entityuuid, ensemble=ensemblename)
+
+            if len(sc) != tot_hits:
+                raise Exception(
+                    "Filtering on realization is not allowed for table and parameter aggregation."
+                )
+        return caseuuid, classname, entityuuid, ensemblename
 
     def __prepare_aggregation_spec(
         self, caseuuid, classname, entityuuid, ensemblename, operation, columns
@@ -1613,8 +1577,22 @@ class SearchContext:
         )
         sc = self if columns is None else self.filter(column=columns)
         query = sc.__prepare_verify_aggregation_query()
-        sres = (await self._sumo.post_async("/search", json=query)).json()
-        return sc.__verify_aggregation_operation_async(sres)
+        caseuuid, classname, entityuuid, ensemblename, tot_hits = (
+            await self._sumo.post_async("/search", json=query)
+        ).json()
+
+        if classname != "surface":
+            sc = SearchContext(
+                sumo=self._sumo,
+                must=[{"exists": {"field": "fmu.realization.id"}}],
+            ).filter(entity=entityuuid, ensemble=ensemblename)
+
+            tot_reals = await sc.length_async()
+            if tot_reals != tot_hits:
+                raise Exception(
+                    "Filtering on realization is not allowed for table and parameter aggregation."
+                )
+        return caseuuid, classname, entityuuid, ensemblename
 
     async def _aggregate_async(
         self, columns=None, operation=None

--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -1502,6 +1502,16 @@ class SearchContext:
             "key"
         ]
         classname = sres["aggregations"]["class"]["buckets"][0]["key"]
+
+        for i in self._query["bool"]["must"]:
+            if (
+                (i.get("terms") and "fmu.realization.id" in i["terms"])
+                or (i.get("term") and "fmu.realization.id" in i["term"])
+            ) and set(["surface"]) != set(self.classes):
+                raise Exception(
+                    "Filtering on realization is not allowed for table and parameter aggretation."
+                )
+
         return caseuuid, classname, entityuuid, ensemblename
 
     def _verify_aggregation_operation(

--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -1521,8 +1521,9 @@ class SearchContext:
         if classname != "surface":
             sc = SearchContext(
                 sumo=self._sumo,
-                must=[{"exists": {"field": "fmu.realization.id"}}],
-            ).filter(entity=entityuuid, ensemble=ensemblename)
+            ).filter(
+                realization=True, entity=entityuuid, ensemble=ensemblename
+            )
 
             if len(sc) != tot_hits:
                 raise Exception(
@@ -1584,8 +1585,9 @@ class SearchContext:
         if classname != "surface":
             sc = SearchContext(
                 sumo=self._sumo,
-                must=[{"exists": {"field": "fmu.realization.id"}}],
-            ).filter(entity=entityuuid, ensemble=ensemblename)
+            ).filter(
+                realization=True, entity=entityuuid, ensemble=ensemblename
+            )
 
             tot_reals = await sc.length_async()
             if tot_reals != tot_hits:

--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -1503,14 +1503,9 @@ class SearchContext:
         ]
         classname = sres["aggregations"]["class"]["buckets"][0]["key"]
 
-        for i in self._query["bool"]["must"]:
-            if (
-                (i.get("terms") and "fmu.realization.id" in i["terms"])
-                or (i.get("term") and "fmu.realization.id" in i["term"])
-            ) and set("surface") != set(self.classes):
-                raise Exception(
-                    "Filtering on realization is not allowed for table and parameter aggretation."
-                )
+        sc=SearchContext(sumo=self._sumo, must=[{"exists": {"field":  "fmu.realization.id"}}]).filter(entity=entityuuid, ensemble=ensemblename)
+        if len(sc) != tot_hits and classname != "surface":
+            raise Exception("Filtering on realization is not allowed for table and parameter aggregation.")
 
         return caseuuid, classname, entityuuid, ensemblename
 

--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -1507,7 +1507,7 @@ class SearchContext:
             if (
                 (i.get("terms") and "fmu.realization.id" in i["terms"])
                 or (i.get("term") and "fmu.realization.id" in i["term"])
-            ) and set(["surface"]) != set(self.classes):
+            ) and set("surface") != set(self.classes):
                 raise Exception(
                     "Filtering on realization is not allowed for table and parameter aggretation."
                 )


### PR DESCRIPTION
Linked issue: https://github.com/equinor/sumo-fmu-aggregation-service/issues/401

In explorer, we check if there is a filter on realization for table and parameter aggregation, if there is, raise an exception. 

We raise an exception:
`Exception: Filtering on realization is not allowed for table and parameter aggretation.`


