### PR TITLE
feat: added aggregation for fnv-1a checksum over specified field.

### DIFF
--- a/src/fmu/sumo/explorer/objects/_metrics.py
+++ b/src/fmu/sumo/explorer/objects/_metrics.py
@@ -298,7 +298,7 @@ class Metrics:
                 for (st in states) {
                     h ^= st.h; c += st.count; t += st.total
                 }
-                return ['xor_fnv64_hex': Long.toHexString(h), 'docs_seen': c, 'total': t];
+                return ['checksum': Long.toHexString(h), 'docs_in_checksum': c, 'docs_total': t];
             """,
         }
 

--- a/src/fmu/sumo/explorer/objects/_metrics.py
+++ b/src/fmu/sumo/explorer/objects/_metrics.py
@@ -279,6 +279,7 @@ class Metrics:
                 state.h = state.count = state.total = 0L;
             """,
             "map_script": f"""
+                state.total++;
                 if (doc['{field}'].size() == 0) return;
                 def s = doc.get('{field}').value;
                 long h = -3750763034362895579L;
@@ -288,7 +289,6 @@ class Metrics:
                 }}
                 state.h ^= h;
                 state.count++;
-                state.total++;
             """,
             "combine_script": """
                 return state;

--- a/src/fmu/sumo/explorer/objects/_metrics.py
+++ b/src/fmu/sumo/explorer/objects/_metrics.py
@@ -272,3 +272,56 @@ class Metrics:
                 "percentiles", field=field, percents=percents
             )
         )["values"]
+
+    def _fnv1a_script(self, field):
+        return {
+            "init_script": """
+                state.h = state.count = state.total = 0L;
+            """,
+            "map_script": f"""
+                if (doc['{field}'].size() == 0) return;
+                def s = doc.get('{field}').value;
+                long h = -3750763034362895579L;
+                for (int i = 0; i < s.length(); i++) {{
+                    h ^= (long) s.charAt(i);
+                    h *= 1099511628211L;
+                }}
+                state.h ^= h;
+                state.count++;
+                state.total++;
+            """,
+            "combine_script": """
+                return state;
+            """,
+            "reduce_script": """
+                long h = 0, c = 0, t = 0;
+                for (st in states) {
+                    h ^= st.h; c += st.count; t += st.total
+                }
+                return ['xor_fnv64_hex': Long.toHexString(h), 'docs_seen': c, 'total': t];
+            """,
+        }
+
+    def fnv1a(self, field):
+        """Compute the 64-bit FNV-1a checksum for field over the current set of objects.
+
+        Arguments:
+            - field (str): the name of a property in the metadata.
+
+        Returns:
+            - a dict with the keys "docs_all", "docs_seen" and "xor_fnv64_hex".
+        """
+        return self._aggregate("scripted_metric", **self._fnv1a_script(field))
+
+    async def fnv1a_async(self, field):
+        """Compute the 64-bit FNV-1a checksum for field over the current set of objects.
+
+        Arguments:
+            - field (str): the name of a property in the metadata.
+
+        Returns:
+            - a dict with the keys "docs_all", "docs_seen" and "xor_fnv64_hex".
+        """
+        return await self._aggregate_async(
+            "scripted_metric", **self._fnv1a_script(field)
+        )


### PR DESCRIPTION
This can be used for a quick check for changes in document (blob) content by getting a checksum over `_sumo.blob_md5.keyword` or `file.checksum_md5.keyword`.

Suggested by Sigurd Pettersen.