### PR TITLE
fix: adjustments to batch aggregation

### DIFF
--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -1640,7 +1640,7 @@ class SearchContext:
         """
         assert operation == "collection"
         assert type(columns) is list and len(columns) > 0
-        columns = self.match_field_values("data.spec.columns.keyword", columns)
+        assert len(columns) < 1000, "Maximum 1000 columns allowed for a single call to batch_aggregate."
         sc = self.filter(realization=True, column=columns)
         if len(sc.hidden) > 0:
             sc = sc.hidden
@@ -1736,9 +1736,7 @@ class SearchContext:
         """
         assert operation == "collection"
         assert type(columns) is list and len(columns) > 0
-        columns = await self.match_field_values_async(
-            "data.spec.columns.keyword", columns
-        )
+        assert len(columns) < 1000, "Maximum 1000 columns allowed for a single call to batch_aggregate."
         sc = self.filter(realization=True, column=columns)
         if len(sc.hidden) > 0:
             sc = sc.hidden

--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -1736,7 +1736,7 @@ class SearchContext:
         """
         assert operation == "collection"
         assert type(columns) is list and len(columns) > 0
-        assert len(columns) < 1000, "Maximum 1000 columns allowed for a single call to batch_aggregate."
+        assert len(columns) < 1000, "Maximum 1000 columns allowed for a single call to batch_aggregate_async."
         sc = self.filter(realization=True, column=columns)
         if len(sc.hidden) > 0:
             sc = sc.hidden

--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -1640,7 +1640,9 @@ class SearchContext:
         """
         assert operation == "collection"
         assert type(columns) is list and len(columns) > 0
-        assert len(columns) < 1000, "Maximum 1000 columns allowed for a single call to batch_aggregate."
+        assert len(columns) < 1000, (
+            "Maximum 1000 columns allowed for a single call to batch_aggregate."
+        )
         sc = self.filter(realization=True, column=columns)
         if len(sc.hidden) > 0:
             sc = sc.hidden
@@ -1736,7 +1738,9 @@ class SearchContext:
         """
         assert operation == "collection"
         assert type(columns) is list and len(columns) > 0
-        assert len(columns) < 1000, "Maximum 1000 columns allowed for a single call to batch_aggregate_async."
+        assert len(columns) < 1000, (
+            "Maximum 1000 columns allowed for a single call to batch_aggregate_async."
+        )
         sc = self.filter(realization=True, column=columns)
         if len(sc.hidden) > 0:
             sc = sc.hidden


### PR DESCRIPTION
fix: do not do regular expression expansion of patterns in batch_aggregate/batch_aggregate_async; the user needs to do this explicitly.

fix: limit batch_aggregate/batch_aggregate_async to max 1000 columns at a time.

