### PR TITLE
fix: modify filter for 'parameters' objects

### DIFF
--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -1278,8 +1278,8 @@ class SearchContext:
                                 "must": [
                                     {"term": {"class.keyword": "dictionary"}},
                                     {
-                                        "exists": {
-                                            "field": "fmu.realization.id"
+                                        "term": {
+                                            "fmu.context.stage.keyword": "realization"
                                         }
                                     },
                                 ]
@@ -1290,8 +1290,11 @@ class SearchContext:
                                 "must": [
                                     {"term": {"class.keyword": "table"}},
                                     {
-                                        "exists": {
-                                            "field": "fmu.aggregation.operation"
+                                        "terms": {
+                                            "fmu.context.stage.keyword": [
+                                                "ensemble",
+                                                "iteration",
+                                            ]
                                         }
                                     },
                                 ]


### PR DESCRIPTION
fix: modify filter for 'parameters' objects, so that it also selects uploaded ensemble parameters (equivalent to aggregated objects).
