### PR TITLE
fix: allow openvds on python 3.12

### DIFF
--- a/docs/explorer.rst
+++ b/docs/explorer.rst
@@ -34,7 +34,7 @@ Api Reference
 - `API reference <apiref/fmu.sumo.explorer.html>`_
 
 .. warning::
-    OpenVDS does not publish builds for MacOS nor for Python version 3.12. You can still use the
+    OpenVDS does not publish builds for MacOS. You can still use the
     Explorer without OpenVDS, but some Cube methods will not work.
 
 Usage and examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,14 +27,14 @@ all = [
   "xtgeo",
   "pandas>=1.1.3",
   "pyarrow; python_version > '3.6.1'",
-  "OpenVDS; sys_platform != 'darwin' and python_version < '3.12'",
+  "OpenVDS; sys_platform != 'darwin'",
 ]
 dev = ["ruff", "pytest"]
 test = [
   "xtgeo",
   "pandas>=1.1.3",
   "pyarrow; python_version > '3.6.1'",
-  "OpenVDS; sys_platform != 'darwin' and python_version < '3.12'",
+  "OpenVDS; sys_platform != 'darwin'",
   "pytest",
   "pytest-timeout",
 ]

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -2,7 +2,7 @@
 
 import sys
 
-if not sys.platform.startswith("darwin") and sys.version_info < (3, 12):
+if not sys.platform.startswith("darwin"):
     import openvds
 import json
 import logging
@@ -331,8 +331,8 @@ def test_get_case_by_uuid(explorer: Explorer, case_uuid: str, case_name: str):
 
 
 @pytest.mark.skipif(
-    sys.platform.startswith("darwin") or sys.version_info > (3, 12),
-    reason="do not run OpenVDS SEGYImport on mac os or python 3.12",
+    sys.platform.startswith("darwin"),
+    reason="do not run OpenVDS SEGYImport on mac os",
 )
 def test_seismic_case_by_uuid(explorer: Explorer, seismic_case_uuid: str):
     """Test that explorer returns openvds compatible cubes for seismic case"""


### PR DESCRIPTION
## Issue
Closes #406

## Description
OpenVDS is now available for Python 3.12. This PR removes the check on `python < 3.12` when installing or using OpenVDS.

## How to test
Make a Python `3.12` environment and do `pip install openvds` (Does not work on Mac, use Linux (tgx) or Windows)

## Checklist
- [x] No redundant `print()` statements, commented-out code, or other remnants from the development 👀
- [x] New/refactored code is following same conventions as the rest of the code base 🧬
- [x] New/refactored code is tested ⚙
- [x] Documentation has been updated 🧾
- [x] Commits are semantic ✅
