### PR TITLE
feature: partitioned terms aggregation

### DIFF
--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -230,6 +230,25 @@ def _build_composite_query(query, fields, size):
     }
 
 
+def _extract_buckets(bucketlist, field=None):
+    if field is not None:
+        return [
+            {
+                "key": bucket["key"][field],
+                "doc_count": bucket["doc_count"],
+            }
+            for bucket in bucketlist
+        ]
+    else:
+        return [
+            {
+                "key": bucket["key"],
+                "doc_count": bucket["doc_count"],
+            }
+            for bucket in bucketlist
+        ]
+
+
 def _extract_composite_results(res):
     aggs = res["aggregations"]["composite"]
     after_key = aggs.get("after_key")
@@ -768,14 +787,7 @@ class SearchContext:
         res = self._sumo.post("/search", json=query).json()
         other_docs_count = res["aggregations"][field]["sum_other_doc_count"]
         if other_docs_count == 0:
-            buckets = res["aggregations"][field]["buckets"]
-            buckets = [
-                {
-                    "key": bucket["key"],
-                    "doc_count": bucket["doc_count"],
-                }
-                for bucket in buckets
-            ]
+            buckets = _extract_buckets(res["aggregations"][field]["buckets"])
             return buckets
 
         query = _build_bucket_query(self._query, field, buckets_per_batch)
@@ -788,18 +800,13 @@ class SearchContext:
                 )
                 res = self._sumo.post("/search", json=query).json()
                 pit.update_from_result(res)
-                buckets = res["aggregations"][field]["buckets"]
+                buckets = _extract_buckets(
+                    res["aggregations"][field]["buckets"], field
+                )
                 if len(buckets) == 0:
                     break
                 after_key = res["aggregations"][field]["after_key"]
-                buckets = [
-                    {
-                        "key": bucket["key"][field],
-                        "doc_count": bucket["doc_count"],
-                    }
-                    for bucket in buckets
-                ]
-                all_buckets = all_buckets + buckets
+                all_buckets.extend(buckets)
                 if len(buckets) < buckets_per_batch:
                     break
                 pass
@@ -831,15 +838,10 @@ class SearchContext:
                 }
                 qdoc = pit.stamp_query(qdoc)
                 res = self._sumo.post("/search", json=qdoc).json()
-                buckets = res["aggregations"]["values"]["buckets"]
-                buckets = [
-                    {
-                        "key": bucket["key"],
-                        "doc_count": bucket["doc_count"],
-                    }
-                    for bucket in buckets
-                ]
-                all_buckets = all_buckets + buckets
+                buckets = _extract_buckets(
+                    res["aggregations"]["values"]["buckets"]
+                )
+                all_buckets.extend(buckets)
 
         return all_buckets
 
@@ -865,14 +867,7 @@ class SearchContext:
         res = (await self._sumo.post_async("/search", json=query)).json()
         other_docs_count = res["aggregations"][field]["sum_other_doc_count"]
         if other_docs_count == 0:
-            buckets = res["aggregations"][field]["buckets"]
-            buckets = [
-                {
-                    "key": bucket["key"],
-                    "doc_count": bucket["doc_count"],
-                }
-                for bucket in buckets
-            ]
+            buckets = _extract_buckets(res["aggregations"][field]["buckets"])
             return buckets
 
         query = _build_bucket_query(self._query, field, buckets_per_batch)
@@ -886,18 +881,13 @@ class SearchContext:
                 res = await self._sumo.post_async("/search", json=query)
                 res = res.json()
                 pit.update_from_result(res)
-                buckets = res["aggregations"][field]["buckets"]
+                buckets = _extract_buckets(
+                    res["aggregations"][field]["buckets"], field
+                )
                 if len(buckets) == 0:
                     break
                 after_key = res["aggregations"][field]["after_key"]
-                buckets = [
-                    {
-                        "key": bucket["key"][field],
-                        "doc_count": bucket["doc_count"],
-                    }
-                    for bucket in buckets
-                ]
-                all_buckets = all_buckets + buckets
+                all_buckets.extend(buckets)
                 if len(buckets) < buckets_per_batch:
                     break
                 pass
@@ -931,15 +921,10 @@ class SearchContext:
                 res = (
                     await self._sumo.post_async("/search", json=qdoc)
                 ).json()
-                buckets = res["aggregations"]["values"]["buckets"]
-                buckets = [
-                    {
-                        "key": bucket["key"],
-                        "doc_count": bucket["doc_count"],
-                    }
-                    for bucket in buckets
-                ]
-                all_buckets = all_buckets + buckets
+                buckets = _extract_buckets(
+                    res["aggregations"]["values"]["buckets"]
+                )
+                all_buckets.extend(buckets)
 
         return all_buckets
 

--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -856,7 +856,7 @@ class SearchContext:
             A List of unique values for a given field
         """
 
-        buckets_per_batch = 1000
+        buckets_per_batch = 10000
 
         # fast path: try without Pit
         query = _build_bucket_query_simple(
@@ -954,7 +954,8 @@ class SearchContext:
         """
         if field not in self._field_values_and_counts:
             buckets = {
-                b["key"]: b["doc_count"] for b in self._get_buckets_partitioned(field)
+                b["key"]: b["doc_count"]
+                for b in self._get_buckets_partitioned(field)
             }
             self._field_values_and_counts[field] = buckets
 

--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -809,7 +809,6 @@ class SearchContext:
     def _get_buckets_partitioned(self, field: str) -> List[Dict]:
         buckets_per_partition = 10000
         nvals = self.metrics.cardinality(field)
-        print(f"Cardinality: {nvals}")
         num_partitions = math.ceil(nvals / buckets_per_partition)
         all_buckets = []
         with Pit(self._sumo, "1m") as pit:
@@ -908,7 +907,6 @@ class SearchContext:
     async def _get_buckets_partitioned_async(self, field: str) -> List[Dict]:
         buckets_per_partition = 10000
         nvals = await self.metrics.cardinality_async(field)
-        print(f"Cardinality: {nvals}")
         num_partitions = math.ceil(nvals / buckets_per_partition)
         all_buckets = []
         async with Pit(self._sumo, "1m") as pit:

--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import warnings
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
@@ -343,12 +344,12 @@ class SearchContext:
             if len(must) == 1:
                 return must[0]
             else:
-                return {"bool": {"must": must}}
+                return {"bool": {"filter": must}}
         else:
             if len(must) == 0:
                 return {"bool": {"must_not": must_not}}
             else:
-                return {"bool": {"must": must, "must_not": must_not}}
+                return {"bool": {"filter": must, "must_not": must_not}}
 
     def _to_sumo(self, obj, blob=None) -> objects.Document:
         cls = obj["_source"]["class"]
@@ -758,7 +759,7 @@ class SearchContext:
             A List of unique values for a given field
         """
 
-        buckets_per_batch = 1000
+        buckets_per_batch = 10000
 
         # fast path: try without Pit
         query = _build_bucket_query_simple(
@@ -803,6 +804,48 @@ class SearchContext:
                     break
                 pass
 
+        return all_buckets
+
+    def _get_buckets_partitioned(self, field: str) -> List[Dict]:
+        qdoc = {
+            "query": self._query,
+            "size": 0,
+            "aggs": {
+                "nvals": {
+                    "cardinality": {
+                        "field": field
+                        }
+                    }
+                }
+            }
+        res = self._sumo.post("/search", json=qdoc).json()
+        nvals = res["aggregations"]["nvals"]["value"]
+        print(f"Cardinality: {nvals}")
+        num_partitions = math.ceil(nvals / 10000) + 1
+        all_buckets = {}
+        with Pit(self._sumo, "1m") as pit:
+            for p in range(num_partitions):
+                qdoc = {
+                    "query": self._query,
+                    "size": 0,
+                    "aggs": {
+                        "values": {
+                            "terms": {
+                                "field": field,
+                                "include": {
+                                    "partition": p,
+                                    "num_partitions": num_partitions,
+                                },
+                                "size": 10000
+                            }
+                        }
+                    },
+                }
+                qdoc = pit.stamp_query(qdoc)
+                res = self._sumo.post("/search", json=qdoc).json()
+                buckets = {b["key"]: b["doc_count"] for b in res["aggregations"]["values"]["buckets"]}
+                all_buckets |= buckets
+            
         return all_buckets
 
     async def _get_buckets_async(

--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -807,22 +807,17 @@ class SearchContext:
         return all_buckets
 
     def _get_buckets_partitioned(self, field: str) -> List[Dict]:
+        buckets_per_partition = 10000
         qdoc = {
             "query": self._query,
             "size": 0,
-            "aggs": {
-                "nvals": {
-                    "cardinality": {
-                        "field": field
-                        }
-                    }
-                }
-            }
+            "aggs": {"nvals": {"cardinality": {"field": field}}},
+        }
         res = self._sumo.post("/search", json=qdoc).json()
         nvals = res["aggregations"]["nvals"]["value"]
         print(f"Cardinality: {nvals}")
-        num_partitions = math.ceil(nvals / 10000) + 1
-        all_buckets = {}
+        num_partitions = math.ceil(nvals / buckets_per_partition)
+        all_buckets = []
         with Pit(self._sumo, "1m") as pit:
             for p in range(num_partitions):
                 qdoc = {
@@ -836,16 +831,23 @@ class SearchContext:
                                     "partition": p,
                                     "num_partitions": num_partitions,
                                 },
-                                "size": 10000
+                                "size": buckets_per_partition,
                             }
                         }
                     },
                 }
                 qdoc = pit.stamp_query(qdoc)
                 res = self._sumo.post("/search", json=qdoc).json()
-                buckets = {b["key"]: b["doc_count"] for b in res["aggregations"]["values"]["buckets"]}
-                all_buckets |= buckets
-            
+                buckets = res["aggregations"]["values"]["buckets"]
+                buckets = [
+                    {
+                        "key": bucket["key"],
+                        "doc_count": bucket["doc_count"],
+                    }
+                    for bucket in buckets
+                ]
+                all_buckets = all_buckets + buckets
+
         return all_buckets
 
     async def _get_buckets_async(
@@ -906,6 +908,52 @@ class SearchContext:
                 if len(buckets) < buckets_per_batch:
                     break
                 pass
+
+        return all_buckets
+
+    async def _get_buckets_partitioned_async(self, field: str) -> List[Dict]:
+        buckets_per_partition = 10000
+        qdoc = {
+            "query": self._query,
+            "size": 0,
+            "aggs": {"nvals": {"cardinality": {"field": field}}},
+        }
+        res = (await self._sumo.post_async("/search", json=qdoc)).json()
+        nvals = res["aggregations"]["nvals"]["value"]
+        print(f"Cardinality: {nvals}")
+        num_partitions = math.ceil(nvals / buckets_per_partition)
+        all_buckets = []
+        async with Pit(self._sumo, "1m") as pit:
+            for p in range(num_partitions):
+                qdoc = {
+                    "query": self._query,
+                    "size": 0,
+                    "aggs": {
+                        "values": {
+                            "terms": {
+                                "field": field,
+                                "include": {
+                                    "partition": p,
+                                    "num_partitions": num_partitions,
+                                },
+                                "size": buckets_per_partition,
+                            }
+                        }
+                    },
+                }
+                qdoc = pit.stamp_query(qdoc)
+                res = (
+                    await self._sumo.post_async("/search", json=qdoc)
+                ).json()
+                buckets = res["aggregations"]["values"]["buckets"]
+                buckets = [
+                    {
+                        "key": bucket["key"],
+                        "doc_count": bucket["doc_count"],
+                    }
+                    for bucket in buckets
+                ]
+                all_buckets = all_buckets + buckets
 
         return all_buckets
 

--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -954,7 +954,7 @@ class SearchContext:
         """
         if field not in self._field_values_and_counts:
             buckets = {
-                b["key"]: b["doc_count"] for b in self._get_buckets(field)
+                b["key"]: b["doc_count"] for b in self._get_buckets_partitioned(field)
             }
             self._field_values_and_counts[field] = buckets
 
@@ -970,7 +970,7 @@ class SearchContext:
             A List of unique values for the given field
         """
         if field not in self._field_values:
-            buckets = self._get_buckets(field)
+            buckets = self._get_buckets_partitioned(field)
             self._field_values[field] = [bucket["key"] for bucket in buckets]
 
         return self._field_values[field]
@@ -1023,7 +1023,7 @@ class SearchContext:
         if field not in self._field_values_and_counts:
             buckets = {
                 b["key"]: b["doc_count"]
-                for b in await self._get_buckets_async(field)
+                for b in await self._get_buckets_partitioned_async(field)
             }
             self._field_values_and_counts[field] = buckets
 
@@ -1039,7 +1039,7 @@ class SearchContext:
             A List of unique values for the given field
         """
         if field not in self._field_values:
-            buckets = await self._get_buckets_async(field)
+            buckets = await self._get_buckets_partitioned_async(field)
             self._field_values[field] = [bucket["key"] for bucket in buckets]
 
         return self._field_values[field]

--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -808,13 +808,7 @@ class SearchContext:
 
     def _get_buckets_partitioned(self, field: str) -> List[Dict]:
         buckets_per_partition = 10000
-        qdoc = {
-            "query": self._query,
-            "size": 0,
-            "aggs": {"nvals": {"cardinality": {"field": field}}},
-        }
-        res = self._sumo.post("/search", json=qdoc).json()
-        nvals = res["aggregations"]["nvals"]["value"]
+        nvals = self.metrics.cardinality(field)
         print(f"Cardinality: {nvals}")
         num_partitions = math.ceil(nvals / buckets_per_partition)
         all_buckets = []
@@ -913,13 +907,7 @@ class SearchContext:
 
     async def _get_buckets_partitioned_async(self, field: str) -> List[Dict]:
         buckets_per_partition = 10000
-        qdoc = {
-            "query": self._query,
-            "size": 0,
-            "aggs": {"nvals": {"cardinality": {"field": field}}},
-        }
-        res = (await self._sumo.post_async("/search", json=qdoc)).json()
-        nvals = res["aggregations"]["nvals"]["value"]
+        nvals = await self.metrics.cardinality_async(field)
         print(f"Cardinality: {nvals}")
         num_partitions = math.ceil(nvals / buckets_per_partition)
         all_buckets = []

--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -843,7 +843,7 @@ class SearchContext:
                 )
                 all_buckets.extend(buckets)
 
-        return all_buckets
+        return sorted(all_buckets, key=lambda b: b["key"])
 
     async def _get_buckets_async(
         self,
@@ -926,7 +926,7 @@ class SearchContext:
                 )
                 all_buckets.extend(buckets)
 
-        return all_buckets
+        return sorted(all_buckets, key=lambda b: b["key"])
 
     def get_field_values_and_counts(self, field: str) -> Dict[str, int]:
         """Get List of unique values with occurrence counts for a given field

--- a/src/fmu/sumo/explorer/objects/_search_context.py
+++ b/src/fmu/sumo/explorer/objects/_search_context.py
@@ -233,18 +233,18 @@ def _build_composite_query(query, fields, size):
 def _extract_buckets(bucketlist, field=None):
     if field is not None:
         return [
-            {
-                "key": bucket["key"][field],
-                "doc_count": bucket["doc_count"],
-            }
+            (
+                bucket["key"][field],
+                bucket["doc_count"],
+            )
             for bucket in bucketlist
         ]
     else:
         return [
-            {
-                "key": bucket["key"],
-                "doc_count": bucket["doc_count"],
-            }
+            (
+                bucket["key"],
+                bucket["doc_count"],
+            )
             for bucket in bucketlist
         ]
 
@@ -843,7 +843,7 @@ class SearchContext:
                 )
                 all_buckets.extend(buckets)
 
-        return sorted(all_buckets, key=lambda b: b["key"])
+        return sorted(all_buckets, key=lambda b: b[1])
 
     async def _get_buckets_async(
         self,
@@ -926,7 +926,7 @@ class SearchContext:
                 )
                 all_buckets.extend(buckets)
 
-        return sorted(all_buckets, key=lambda b: b["key"])
+        return sorted(all_buckets, key=lambda b: b[1])
 
     def get_field_values_and_counts(self, field: str) -> Dict[str, int]:
         """Get List of unique values with occurrence counts for a given field
@@ -939,8 +939,7 @@ class SearchContext:
         """
         if field not in self._field_values_and_counts:
             buckets = {
-                b["key"]: b["doc_count"]
-                for b in self._get_buckets_partitioned(field)
+                b[0]: b[1] for b in self._get_buckets_partitioned(field)
             }
             self._field_values_and_counts[field] = buckets
 
@@ -957,7 +956,7 @@ class SearchContext:
         """
         if field not in self._field_values:
             buckets = self._get_buckets_partitioned(field)
-            self._field_values[field] = [bucket["key"] for bucket in buckets]
+            self._field_values[field] = [bucket[0] for bucket in buckets]
 
         return self._field_values[field]
 
@@ -1008,7 +1007,7 @@ class SearchContext:
         """
         if field not in self._field_values_and_counts:
             buckets = {
-                b["key"]: b["doc_count"]
+                b[0]: b[1]
                 for b in await self._get_buckets_partitioned_async(field)
             }
             self._field_values_and_counts[field] = buckets
@@ -1026,7 +1025,7 @@ class SearchContext:
         """
         if field not in self._field_values:
             buckets = await self._get_buckets_partitioned_async(field)
-            self._field_values[field] = [bucket["key"] for bucket in buckets]
+            self._field_values[field] = [bucket[0] for bucket in buckets]
 
         return self._field_values[field]
 

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -426,3 +426,25 @@ def test_reference_realization_fallback(explorer: Explorer):
             assert len(set(refids).difference([0, 1])) == 0
             pass
         pass
+
+
+def test_buckets_partitioned(explorer: Explorer):
+    ensembles = (
+        explorer.tables.filter(
+            asset="Troll", tagname="summary", realization=True
+        )
+        .ensembles.sort({"_sumo.timestamp": {"order": "desc"}})
+        .limit(10)
+    )
+    for ens in ensembles:
+        print(ens)
+        tables = ens.tables.filter(tagname="summary", realization=True)
+        res_p = tables._get_buckets_partitioned("data.spec.columns.keyword")
+        res_c = tables._get_buckets("data.spec.columns.keyword")
+        col_p = {b["key"] for b in res_p}
+        col_c = {b["key"] for b in res_c}
+        print(f"len(col_p) = {len(col_p)}")
+        print(f"len(col_c) = {len(col_c)}")
+
+        diff = col_p.symmetric_difference(col_c)
+        assert len(diff) == 0

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -441,8 +441,8 @@ def test_buckets_partitioned(explorer: Explorer):
         tables = ens.tables.filter(tagname="summary", realization=True)
         res_p = tables._get_buckets_partitioned("data.spec.columns.keyword")
         res_c = tables._get_buckets("data.spec.columns.keyword")
-        col_p = {b["key"] for b in res_p}
-        col_c = {b["key"] for b in res_c}
+        col_p = {b[0] for b in res_p}
+        col_c = {b[0] for b in res_c}
         print(f"len(col_p) = {len(col_p)}")
         print(f"len(col_c) = {len(col_c)}")
 

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -437,14 +437,11 @@ def test_buckets_partitioned(explorer: Explorer):
         .limit(10)
     )
     for ens in ensembles:
-        print(ens)
         tables = ens.tables.filter(tagname="summary", realization=True)
         res_p = tables._get_buckets_partitioned("data.spec.columns.keyword")
         res_c = tables._get_buckets("data.spec.columns.keyword")
         col_p = {b[0] for b in res_p}
         col_c = {b[0] for b in res_c}
-        print(f"len(col_p) = {len(col_p)}")
-        print(f"len(col_c) = {len(col_c)}")
 
         diff = col_p.symmetric_difference(col_c)
         assert len(diff) == 0


### PR DESCRIPTION
## Issue
Closes #473 

## Description
Previously, we have used composite aggregation to get all property values for a selection, if the number of values was larger than what Elasticsearch support. Composite aggregation is limited to 65535 different terms, and we have already seen
ensembles close to this limit. 

Partitioned terms aggregation does not have this limitation, and appears to be slightly faster.

## How to test
`pytest -s -v tests/test_explorer.py -k test_buckets_partitioned`

For a more complete test, edit the test `test_buckets_partitioned` in `tests/test_explorer.py` to test more ensembles, or ensembles with more data.

## Checklist
- [x] No redundant `print()` statements, commented-out code, or other remnants from the development 👀
- [x] New/refactored code is following same conventions as the rest of the code base 🧬
- [x] New/refactored code is tested ⚙
- [x] Documentation has been updated 🧾
- [x] Commits are semantic ✅
