### PR TITLE
fix: require sumo-wrapper-python>=1.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,10 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
 ]
-dependencies = ["sumo-wrapper-python", "deprecation"]
+dependencies = [
+  "sumo-wrapper-python>=1.6.1",
+  "deprecation"
+]
 
 [project.urls]
 Repository = "https://github.com/equinor/fmu-sumo"


### PR DESCRIPTION
## Issue
Got a report from a user on Slack where requests were failing with `404`.
This was due to having an old version of `sumo-wrapper-python` that had an old url.

## Description
Pin `sumo-wrapper-python>=1.6.1` (newest release) to ensure that the wrapper will be updated as well.
We should update this pin when doing larger updates to the wrapper.

## How to test
In an environment with `sumo-wrapper-python<1.6.1` installed. Do `pip install .` (from this branch) and verify that `sumo-wrapper-python==1.6.1` is installed.

## Checklist
- [x] No redundant `print()` statements, commented-out code, or other remnants from the development 👀
- [x] New/refactored code is following same conventions as the rest of the code base 🧬
- [x] New/refactored code is tested ⚙
- [ ] Documentation has been updated 🧾
- [x] Commits are semantic ✅
